### PR TITLE
read flux bounds and optimization coefficients from FBC extensions

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -50,9 +50,10 @@ Structure that collects the model-related data. Contains `units`,
 indexed by identifiers of the corresponding objects.
 """
 struct Model
+    params::Dict{String,Float64}
     units::Dict{String,Vector{UnitPart}}
     compartments::Vector{String}
     species::Dict{String,Species}
     reactions::Dict{String,Reaction}
-    Model(u, c, s, r) = new(u, c, s, r)
+    Model(p, u, c, s, r) = new(p, u, c, s, r)
 end


### PR DESCRIPTION
...this doesn't finish the story though, as there is at least 1 more way to specify the bounds in SBML. Will add implementation as needed again.

Thanks @stelmo for finding the way to do the plugin typecast -- `libsbml` API docs is completely opaque there. Also, the C versions of the `FluxObjective`-related functions are not even mentioned in the documentation, but seem to be a part of the API nevertheless. I hope they are considered stable.

(cc @htpusa)