### PR TITLE
correctly read gene product associations

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -274,7 +274,6 @@ function extractModel(mdl::VPtr)::Model
                 a = ccall(sbml(:GeneProductAssociation_getAssociation), VPtr, (VPtr,), gpa)
                 a != C_NULL
                 association = getAssociation(a)
-                @info "assoc:" association
             end
         end
 
@@ -284,6 +283,7 @@ function extractModel(mdl::VPtr)::Model
             lb,
             ub,
             haskey(objectives_fbc, reid) ? objectives_fbc[reid] : oc,
+            association,
             getNotes(re),
             getAnnotation(re),
         )

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -28,6 +28,34 @@ struct UnitPart
     UnitPart(k, e, s, m) = new(k, e, s, m)
 end
 
+
+"""
+Abstract type for all kinds of gene product associations
+"""
+abstract type GeneProductAssociation end
+
+"""
+Gene product reference in the association expression
+"""
+struct GPARef <: GeneProductAssociation
+    gene_product::String
+end
+
+"""
+Boolean binary "and" in the association expression
+"""
+struct GPAAnd <: GeneProductAssociation
+    terms::Vector{GeneProductAssociation}
+end
+
+"""
+Boolean binary "or" in the association expression
+"""
+struct GPAOr <: GeneProductAssociation
+    terms::Vector{GeneProductAssociation}
+end
+
+
 """
 Reaction with stoichiometry that assigns reactants and products their relative
 consumption/production rates (accessible in field `stoichiometry`), lower/upper
@@ -39,6 +67,7 @@ struct Reaction
     lb::Tuple{Float64,String}
     ub::Tuple{Float64,String}
     oc::Float64
+    gene_product_association::Maybe{GeneProductAssociation}
     notes::Maybe{String}
     annotation::Maybe{String}
     Reaction(s, l, u, o, n = nothing, a = nothing) = new(s, l, u, o, n, a)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -70,7 +70,7 @@ struct Reaction
     gene_product_association::Maybe{GeneProductAssociation}
     notes::Maybe{String}
     annotation::Maybe{String}
-    Reaction(s, l, u, o, n = nothing, a = nothing) = new(s, l, u, o, n, a)
+    Reaction(s, l, u, o, as, n = nothing, an = nothing) = new(s, l, u, o, as, n, an)
 end
 
 """


### PR DESCRIPTION
`libsbml` is missing the required API, but they have provided a fun workaround.

cc @stelmo 