### PR TITLE
Draft for converting `Model` to `ModelingToolkit` types

### DIFF
--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1,5 +1,9 @@
 create_var(x) = Num(Variable(Symbol(x)))
-create_param(x) = Num(Sym{ModelingToolkit.Parameter{Real}}(Symbol(x)))
+function create_param(x)
+  p = Sym{Real}(Symbol(x))
+  ModelingToolkit.toparam(p)
+  p
+end
 
 
 """ ModelingToolkit.Reaction constructor """

--- a/src/reactionsystem.jl
+++ b/src/reactionsystem.jl
@@ -1,0 +1,38 @@
+create_var(x) = Num(Variable(Symbol(x)))
+create_param(x) = Num(Sym{ModelingToolkit.Parameter{Real}}(Symbol(x)))
+
+
+""" ModelingToolkit.Reaction constructor """
+function ModelingToolkit.Reaction(reaction::Reaction; only_use_rate=true)
+    # pass
+end
+
+
+""" ReactionSystem constructor """
+function ModelingToolkit.ReactionSystem(model::Model)
+    rxs = [Reaction(reac...; only_use_rate=true) for reac in values(model.reactions)]
+    t = Variable(:t)
+    species = [create_var(spec) for spec in keys(model.species)]
+    pars = [create_param(p) for p in keys(model.parameters)]
+    comps = [create_param(c) for c in keys(model.compartments)]
+    pc = vcat(pars,comps)
+    ReactionSystem(rxs,t,species,pc)
+end
+
+
+""" ODESystem constructor """
+function ModelingToolkit.ODESystem(model::Model)
+    rs = ReactionSystem(model)
+    u0map = [create_var(k) => v[2] for (k, v) in model.species]
+    parammap = vcat([create_param(k) => v for (k,v) in model.parameters],
+                    [create_param(k) => v for (k,v) in model.compartments])
+    defaults = vcat(u0map, parammap)
+    convert(ODESystem, rs, defaults=defaults)
+end
+
+
+""" ODEProblem constructor """
+function ModelingToolkit.ODEProblem(model::Model,tspan)  # PL: Todo: add u0 and parameters argument
+    odesys = ODESystem(model)
+    ODEProblem(odesys, [], tspan)
+end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -63,6 +63,7 @@ bounds (in tuples `lb` and `ub`, with unit names), and objective coefficient
 (`oc`). Also may contains `notes` and `annotation`.
 """
 struct Reaction
+    mathml::String
     stoichiometry::Dict{String,Float64}
     lb::Tuple{Float64,String}
     ub::Tuple{Float64,String}
@@ -108,8 +109,8 @@ objects.
 struct Model
     parameters::Dict{String,Float64}
     units::Dict{String,Vector{UnitPart}}
-    compartments::Vector{String}
-    species::Dict{String,Species}
+    compartments::Dict{String,Float64}  # PL: Float64 to describe size
+    species::Dict{String,Tuple{Species,Float64}}  # PL: Tuple of Species and initialAmount
     reactions::Dict{String,Reaction}
     gene_products::Dict{String,GeneProduct}
     notes::Maybe{String}

--- a/src/stuct_suggestions.jl
+++ b/src/stuct_suggestions.jl
@@ -1,0 +1,79 @@
+### This file suggest to possibilities of adapting the types to accommodate also dynamic models
+
+############# Version 1 #################
+abstract type Reaction end
+abstract type Species end
+abstract type SbmlModel end
+
+struct DynamicSpecies <: Species
+    initialAmout::Float64
+    # etc
+end
+
+struct FbaSpecies <: Species
+    # etc
+end
+
+struct DynamicReaction <: Reaction
+    kineticLaw::String
+    # etc
+end
+
+struct FbaReaction <: Reaction
+    lb::Float64
+    ub::Float64
+    # etc
+end
+
+struct DynamicReactionModel <: SbmlModel
+    species::Dict(String,DynamicSpecies)
+    reactions::Dict(String,DynamicReaction)
+    # etc
+end
+
+struct FbaModel <: SbmlModel
+    species::Dict(String,FbaSpecies)
+    reactions::Dict(String,FbaReaction)
+    # etc
+end
+
+############# Version 2 #################
+
+const Maybe{X} = Union{Nothing,X}
+
+struct Reaction
+    kineticLaw::Maybe{String}
+    stoichiometry::Dict{String,Float64}
+    lb::Maybe{Tuple{Float64,String}}
+    ub::Maybe{Tuple{Float64,String}}
+    oc::Maybe{Float64}
+    gene_product_association::Maybe{GeneProductAssociation}
+    notes::Maybe{String}
+    annotation::Maybe{String}
+    Reaction(s, l, u, o, as, n = nothing, an = nothing) = new(s, l, u, o, as, n, an)
+
+end
+
+struct Species
+    initialAmount::Maybe{Float}
+    name::String
+    compartment::Union{String,Tuple{String,Float64}}
+    formula::Maybe{String}
+    charge::Maybe{Int}
+    notes::Maybe{String}
+    annotation::Maybe{String}
+    Species(na, co, f, ch, no = nothing, a = nothing) = new(na, co, f, ch, no, a)
+
+end
+
+struct Model
+    parameters::Dict{String,Float64}
+    units::Dict{String,Vector{UnitPart}}
+    compartments::Vector{String}
+    species::Dict{String,Species}
+    reactions::Dict{String,Reaction}
+    gene_products::Dict{String,GeneProduct}
+    notes::Maybe{String}
+    annotation::Maybe{String}
+    Model(p, u, c, s, r, g, n = nothing, a = nothing) = new(p, u, c, s, r, g, n, a)
+end


### PR DESCRIPTION
This is not working code, but just a rough idea how `Model` can be adapted and further converted to the `ModelingToolkit` types we need. I think we still have to make several more abstract design choices, but perhaps this concrete example helps to get an idea of what is needed.