### PR TITLE
Avoid global namespace creep by `Maybe`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBML"
 uuid = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
 authors = ["Mirek Kratochvil <miroslav.kratochvil@uni.lu>", "LCSB R3 team <lcsb-r3@uni.lu>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -11,6 +11,6 @@ include("utils.jl")
 sbml = (sym::Symbol) -> dlsym(SBML_jll.libsbml_handle, sym)
 
 export SBMLVersion,
-    readSBML, Model, Maybe, UnitPart, Species, Reaction, getS, getLBs, getUBs, getOCs
+    readSBML, Model, UnitPart, Species, Reaction, getS, getLBs, getUBs, getOCs
 
 end # module


### PR DESCRIPTION
# do not export Maybe type to avoid name conflicts

Maybe should *not* be defined by SBML.jl, rather by Base or some other standard
package, but we need it nevertheless. Exporting it means that other packages
will have problems with their own redefinitions of Maybe because name
conflicts. So just do not export it, leave others to redefine it or manually
copy it out, using `const Maybe = SBML.Maybe`.