### PR TITLE
add support for running SBML converters

### DIFF
--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -5,13 +5,15 @@ using SparseArrays
 
 include("structs.jl")
 include("version.jl")
+
 include("readsbml.jl")
+include("converters.jl")
 include("math.jl")
 include("utils.jl")
 
 sbml = (sym::Symbol) -> dlsym(SBML_jll.libsbml_handle, sym)
 
-export SBMLVersion,
-    readSBML, getS, getLBs, getUBs, getOCs
+export SBMLVersion, readSBML, getS, getLBs, getUBs, getOCs
+export convert_level_and_version, libsbml_convert, convert_simplify_math
 
 end # module

--- a/src/converters.jl
+++ b/src/converters.jl
@@ -53,5 +53,5 @@ parameters, and initial assignments in the SBML document.
 """
 convert_simplify_math = libsbml_convert(
     ["promoteLocalParameters", "expandFunctionDefinitions", "setLevelAndVersion"] .=>
-        Dict(),
+        Ref(Dict{String,String}()),
 )

--- a/src/converters.jl
+++ b/src/converters.jl
@@ -1,0 +1,57 @@
+
+"""
+    convert_level_and_version(level, version)
+
+A converter to pass into [`readSBML`](@ref) that enforces certain SBML level
+and version.
+"""
+convert_level_and_version(level, version) =
+    doc -> begin
+        ccall(
+            sbml(:SBMLDocument_setLevelAndVersion),
+            Cint,
+            (VPtr, Cint, Cint),
+            doc,
+            level,
+            version,
+        )
+    end
+
+"""
+    libsbml_convert(conversion_options::Vector{Pair{String, Dict{String, String}}})
+
+A converter that runs the SBML conversion routine, with specified conversion
+options. The argument is a vector of pairs to allow specifying the order of
+conversions.
+"""
+libsbml_convert(conversion_options::Vector{Pair{String,Dict{String,String}}}) =
+    doc -> begin
+        for (converter, options) in conversion_options
+            props = ccall(sbml(:ConversionProperties_create), VPtr, ())
+            opt = ccall(sbml(:ConversionOption_create), VPtr, (Cstring,), converter)
+            ccall(sbml(:ConversionProperties_addOption), Cvoid, (VPtr, VPtr), props, opt)
+            for (k, v) in options
+                opt = ccall(sbml(:ConversionOption_create), VPtr, (Cstring,), k)
+                ccall(sbml(:ConversionOption_setValue), Cvoid, (VPtr, Cstring), opt, v)
+                ccall(
+                    sbml(:ConversionProperties_addOption),
+                    Cvoid,
+                    (VPtr, VPtr),
+                    props,
+                    opt,
+                )
+            end
+            ccall(sbml(:SBMLDocument_convert), Cint, (VPtr, VPtr), doc, props)
+        end
+    end
+
+"""
+    convert_simplify_math
+
+Shortcut for [`libsbml_convert`](@ref) that expands functions, local
+parameters, and initial assignments in the SBML document.
+"""
+convert_simplify_math = libsbml_convert(
+    ["promoteLocalParameters", "expandFunctionDefinitions", "setLevelAndVersion"] .=>
+        Dict(),
+)

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -75,11 +75,11 @@ function get_optional_double(x::VPtr, is_sym, get_sym)::Maybe{Float64}
 end
 
 """
-    function readSBML(fn::String)::SBML.Model
+    function readSBML(fn::String, sbml_conversion = model->nothing)::SBML.Model
 
 Read the SBML from a XML file in `fn` and return the contained `SBML.Model`.
 """
-function readSBML(fn::String)::SBML.Model
+function readSBML(fn::String, sbml_conversion = document -> nothing)::SBML.Model
     doc = ccall(sbml(:readSBML), VPtr, (Cstring,), fn)
     try
         n_errs = ccall(sbml(:SBMLDocument_getNumErrors), Cuint, (VPtr,), doc)
@@ -91,6 +91,8 @@ function readSBML(fn::String)::SBML.Model
         if n_errs > 0
             throw(AssertionError("Opening SBML document has reported errors"))
         end
+
+        sbml_conversion(doc)
 
         if 0 == ccall(sbml(:SBMLDocument_isSetModel), Cint, (VPtr,), doc)
             throw(AssertionError("SBML document contains no model"))


### PR DESCRIPTION
This is the first part of disassembling #40 to tangible pieces.

Generalizes some of the conversion stuff also for other purposes. Conversion for MTK should be now doable easily with something like:
```julia
readSBML("animal.xml",
         doc -> begin
           convert_level_and_version(3, 1)(doc)
           convert_simplify_math(doc)
         end)
```

@paulflang is there some good way/data to test this?