### PR TITLE
parse out and test specially marked time math

### DIFF
--- a/src/math.jl
+++ b/src/math.jl
@@ -24,7 +24,16 @@ pointer to `ASTNode_t`.
 """
 function parse_math(ast::VPtr)::Math
     if ast_is(ast, :ASTNode_isName)
-        return MathIdent(get_string(ast, :ASTNode_getName))
+        if ccall(sbml(:ASTNode_getType), Cint, (VPtr,), ast) == 262
+            # This is a special case checking for the value of "simulation
+            # time" as defined by SBML. The constant `262` is the value of the
+            # enum AST_NAME_TIME in `libsbml/src/sbml/math/ASTNodeType.h`,
+            # needs to be kept up to date with the library (otherwise this
+            # breaks).
+            return MathTime(get_string(ast, :ASTNode_getName))
+        else
+            return MathIdent(get_string(ast, :ASTNode_getName))
+        end
     elseif ast_is(ast, :ASTNode_isConstant)
         return MathConst(get_string(ast, :ASTNode_getName))
     elseif ast_is(ast, :ASTNode_isInteger)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -83,6 +83,14 @@ struct MathConst <: Math
 end
 
 """
+A special value representing the current time of the simulation, with a special
+name.
+"""
+struct MathTime <: Math
+    id::String
+end
+
+"""
 Function application ("call by name", no tricks allowed) in mathematical expression
 """
 struct MathApply <: Math

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -24,6 +24,14 @@ sbmlfiles = [
         2,
         6,
     ),
+    # a cool model with `time` from SBML testsuite
+    (
+        "sbml00852.xml",
+        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00852/00852-sbml-l3v2.xml",
+        "d013765aa358d265941420c2e3d81fcbc24b0aa4e9f39a8dc8852debd1addb60",
+        4,
+        3,
+    ),
 ]
 
 @testset "Loading of models from various sources" begin
@@ -48,4 +56,15 @@ sbmlfiles = [
             @test length(rxns) == expected_rxns
         end
     end
+end
+
+@testset "Time variables in math" begin
+    # this test is here mainly for keeping a magical constant that we need for
+    # parsing time synced with libsbml source
+    contains_time(x::SBML.MathTime) = true
+    contains_time(x::SBML.MathApply) = any(contains_time.(x.args))
+    contains_time(_) = false
+
+    m = readSBML("sbml00852.xml")
+    @test all(contains_time.(r.kinetic_math for (_, r) in m.reactions))
 end


### PR DESCRIPTION
Closes #54

We can eventually ask someone about what's the expected overlap of the Time vs Name features in SBML. This version should kinda handle all of it; if it gets simpler, we can erase the `id` field from time.