### PR TITLE
Strip whitespaces when reporting error messages from `readSBML`

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -99,8 +99,8 @@ function readSBML(fn::String, sbml_conversion = document -> nothing)::SBML.Model
         n_errs = ccall(sbml(:SBMLDocument_getNumErrors), Cuint, (VPtr,), doc)
         for i = 0:n_errs-1
             err = ccall(sbml(:SBMLDocument_getError), VPtr, (VPtr, Cuint), doc, i)
-            msg = get_string(err, :XMLError_getMessage)
-            @warn "SBML reported error: $msg"
+            msg = strip(get_string(err, :XMLError_getMessage))
+            @error "SBML reported error: $msg"
         end
         if n_errs > 0
             throw(AssertionError("Opening SBML document has reported errors"))

--- a/test/ecoli_flux.jl
+++ b/test/ecoli_flux.jl
@@ -18,8 +18,7 @@ end
 
     @test typeof(mdl) == Model
 
-    @info "The next warning is an expected side-effect of testing an error condition"
-    @test_throws AssertionError readSBML(sbmlfile * ".does.not.really.exist")
+    @test_logs (:error, "SBML reported error: File unreadable.") @test_throws AssertionError readSBML(sbmlfile * ".does.not.really.exist")
 
     @test length(mdl.compartments) == 2
 


### PR DESCRIPTION
Also:

* replace `@warn` with `@error`
* actually test the logging message in `readSBML`, instead of showing an extra
  message saying to ignore it.

---

_Old question_:

Related, you may want to use `@error` instead of `@warn` to report the SBML
error?  Or you don't want to scare users too much?