### PR TITLE
Remove `DocumenterTools` from `docs/` environment

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,2 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"


### PR DESCRIPTION
The package doesn't seem to be actually used, as far as I could see.