### PR TITLE
Add SSH key to let TagBot trigger building documentation

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Ref #92.  However after merging this you'll need to manually trigger the rebuild
of the missing version, see the "Fixing broken release deployments" box in
https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#Documentation-Versions