### PR TITLE
quickfix: do not break stoichiometry if 2 species references are present

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -334,13 +334,13 @@ function extractModel(mdl::VPtr)::SBML.Model
 
         # extract stoichiometry
         stoi = Dict{String,Float64}()
-        add_stoi =
-            (sr, factor) -> begin
-                s = get_string(sr, :SpeciesReference_getSpecies)
-                stoi[s] =
-                    get(stoi, s, 0) +
-                    ccall(sbml(:SpeciesReference_getStoichiometry), Cdouble, (VPtr,), sr) * factor
-            end
+        add_stoi(sr, factor) = begin
+            s = get_string(sr, :SpeciesReference_getSpecies)
+            stoi[s] =
+                get(stoi, s, 0) +
+                ccall(sbml(:SpeciesReference_getStoichiometry), Cdouble, (VPtr,), sr) *
+                factor
+        end
 
         # reactants and products
         for j = 1:ccall(sbml(:Reaction_getNumReactants), Cuint, (VPtr,), re)

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -335,10 +335,12 @@ function extractModel(mdl::VPtr)::SBML.Model
         # extract stoichiometry
         stoi = Dict{String,Float64}()
         add_stoi =
-            (sr, factor) ->
-                stoi[get_string(sr, :SpeciesReference_getSpecies)] =
-                    ccall(sbml(:SpeciesReference_getStoichiometry), Cdouble, (VPtr,), sr) *
-                    factor
+            (sr, factor) -> begin
+                s = get_string(sr, :SpeciesReference_getSpecies)
+                stoi[s] =
+                    get(stoi, s, 0) +
+                    ccall(sbml(:SpeciesReference_getStoichiometry), Cdouble, (VPtr,), sr) * factor
+            end
 
         # reactants and products
         for j = 1:ccall(sbml(:Reaction_getNumReactants), Cuint, (VPtr,), re)


### PR DESCRIPTION
This should be sufficient for now (and doesn't break anyone else's code), we'll redo the whole stoichiometry part later anyway.

closes #115 