### PR TITLE
Rename `SBMLVersion` -> `Version` and unexport it

### DIFF
--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -18,7 +18,7 @@ include("utils.jl")
 
 sbml(sym::Symbol) = dlsym(SBML_jll.libsbml_handle, sym)
 
-export SBMLVersion, readSBML, getS, getLBs, getUBs, getOCs
+export readSBML, getS, getLBs, getUBs, getOCs
 export set_level_and_version, libsbml_convert, convert_simplify_math
 
 end # module

--- a/src/version.jl
+++ b/src/version.jl
@@ -1,9 +1,9 @@
 
 """
-    function SBMLVersion()
+    function SBML.Version()
 
 Get the version of the used SBML library in Julia version format.
 """
-function SBMLVersion()::VersionNumber
+function Version()::VersionNumber
     VersionNumber(unsafe_string(ccall(sbml(:getLibSBMLDottedVersion), Cstring, ())))
 end

--- a/test/version.jl
+++ b/test/version.jl
@@ -1,4 +1,4 @@
 
 @testset "CCall to SBML works and SBML returns a version" begin
-    @test SBMLVersion() isa VersionNumber
+    @test SBML.Version() isa VersionNumber
 end


### PR DESCRIPTION
Since we're going to have a breaking version, here is another breaking change.