### PR TITLE
Rename some functions to something easier understand

### DIFF
--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -18,7 +18,7 @@ include("utils.jl")
 
 sbml(sym::Symbol) = dlsym(SBML_jll.libsbml_handle, sym)
 
-export readSBML, getS, getLBs, getUBs, getOCs
+export readSBML, stoichiometry_matrix, flux_bounds, flux_objective
 export set_level_and_version, libsbml_convert, convert_simplify_math
 
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 """
-    function getS(m::SBML.Model; zeros=spzeros)::Tuple{Vector{String},Vector{String},AbstractMatrix{Float64}}
+    function stoichiometry_matrix(m::SBML.Model; zeros=spzeros)::Tuple{Vector{String},Vector{String},AbstractMatrix{Float64}}
 
 Extract the vector of species (aka metabolite) identifiers, vector of reaction
 identifiers, and the (dense) stoichiometry matrix from an existing `SBML.Model`.
@@ -9,7 +9,7 @@ The matrix is sparse by default (initially constructed by
 `SparseArrays.spzeros`). You can fill in a custom empty matrix constructed to
 argument `zeros`; e.g. running with `zeros=zeros` will produce a dense matrix.
 """
-function getS(
+function stoichiometry_matrix(
     m::SBML.Model;
     zeros = spzeros,
 )::Tuple{Vector{String},Vector{String},AbstractMatrix{Float64}}
@@ -25,29 +25,22 @@ function getS(
 end
 
 """
-    getLBs(m::SBML.Model)::Vector{Tuple{Float64,String}}
+    flux_bounds(m::SBML.Model)::NTuple{2, Vector{Tuple{Float64,String}}}
 
-Extract a vector of lower bounds of reaction rates from the model. All bounds
-are accompanied with the unit of the corresponding value (this behavior is
-based on SBML specification).
+Extract the vectors of lower and upper bounds of reaction rates from the model. All bounds
+are accompanied with the unit of the corresponding value (this behavior is based on SBML
+specification).
 """
-getLBs(m::SBML.Model)::Vector{Tuple{Float64,String}} =
-    broadcast(x -> x.lb, values(m.reactions))
-
-"""
-    getUBs(m::SBML.Model)::Vector{Tuple{Float64,String}}
-
-Likewise to [`getLBs`](@ref), extract the upper bounds.
-"""
-getUBs(m::SBML.Model)::Vector{Tuple{Float64,String}} =
-    broadcast(x -> x.ub, values(m.reactions))
+flux_bounds(m::SBML.Model)::NTuple{2,Vector{Tuple{Float64,String}}} =
+    (broadcast(x -> x.lb, values(m.reactions)),
+     broadcast(x -> x.ub, values(m.reactions)))
 
 """
-    getOCs(m::SBML.Model)::Vector{Float64}
+    flux_objective(m::SBML.Model)::Vector{Float64}
 
 Extract the vector of objective coefficients of each reaction.
 """
-getOCs(m::SBML.Model)::Vector{Float64} = broadcast(x -> x.oc, values(m.reactions))
+flux_objective(m::SBML.Model)::Vector{Float64} = broadcast(x -> x.oc, values(m.reactions))
 
 """
     initial_amounts(m::SBML.Model; convert_concentrations = false)

--- a/test/ecoli_flux.jl
+++ b/test/ecoli_flux.jl
@@ -26,11 +26,11 @@ end
 
     @test length(mdl.compartments) == 2
 
-    mets, rxns, S = getS(mdl)
+    mets, rxns, S = stoichiometry_matrix(mdl)
 
     @test typeof(S) <: AbstractMatrix{Float64}
-    @test typeof(getS(mdl; zeros = spzeros)[3]) <: SparseMatrixCSC{Float64}
-    @test typeof(getS(mdl; zeros = zeros)[3]) == Matrix{Float64}
+    @test typeof(stoichiometry_matrix(mdl; zeros = spzeros)[3]) <: SparseMatrixCSC{Float64}
+    @test typeof(stoichiometry_matrix(mdl; zeros = zeros)[3]) == Matrix{Float64}
 
     @test length(mets) == 77
     @test length(rxns) == 77
@@ -41,17 +41,16 @@ end
     @test mets[10:12] == ["M_akg_e", "M_fum_c", "M_pyr_c"]
     @test rxns[10:12] == ["R_H2Ot", "R_PGL", "R_EX_glc_e_"]
 
-    lbs = getLBs(mdl)
-    ubs = getUBs(mdl)
-    ocs = getOCs(mdl)
+    lbs, ubs = flux_bounds(mdl)
+    ocs = flux_objective(mdl)
 
     @test length(ocs) == length(mets)
     @test ocs[40] == 1.0
     deleteat!(ocs, 40)
     @test all(ocs .== 0.0)
 
-    @test length(getLBs(mdl)) == length(rxns)
-    @test length(getUBs(mdl)) == length(rxns)
+    @test length(flux_bounds(mdl)[1]) == length(rxns)
+    @test length(flux_bounds(mdl)[2]) == length(rxns)
 
     getunit((val, unit)) = unit
     @test all([broadcast(getunit, lbs) broadcast(getunit, ubs)] .== "mmol_per_gDW_per_hr")

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -74,7 +74,7 @@ sbmlfiles = [
 
             @test typeof(mdl) == Model
 
-            mets, rxns, _ = getS(mdl)
+            mets, rxns, _ = stoichiometry_matrix(mdl)
 
             @test length(mets) == expected_mets
             @test length(rxns) == expected_rxns


### PR DESCRIPTION
* `getS` -> `stoichiometry_matrix`
* `getLBs`, `getUBs` -> `flux_bounds`
* `getOCs` -> `flux_objective`

Fix #121.