### PR TITLE
Fix checking of errors in `libsbml_convert`

### DIFF
--- a/src/converters.jl
+++ b/src/converters.jl
@@ -46,7 +46,9 @@ libsbml_convert(
                 )
             end
             check_errors(
-                ccall(sbml(:SBMLDocument_convert), Cint, (VPtr, VPtr), doc, props),
+                # `SBMLDocument_convert` returns `LIBSBML_OPERATION_SUCCESS` (== 0) for a
+                # successful operation, something else when there is a failure.
+                iszero(ccall(sbml(:SBMLDocument_convert), Cint, (VPtr, VPtr), doc, props)),
                 doc,
                 ErrorException("Conversion returned errors"),
             )


### PR DESCRIPTION
The function
[`SBMLDocument_convert`](http://sbml.org/Software/libSBML/5.18.0/docs/formatted/c-api/class_s_b_m_l_document__t.html#a96677d1b2225c23f3b3ab662a4e547e2)
returns 0 when it is successful, other numbers otherwise.

Fix #125.