### PR TITLE
Always pass `report_severities` argument to `check_errors`

### DIFF
--- a/src/converters.jl
+++ b/src/converters.jl
@@ -1,11 +1,12 @@
 
 """
-    set_level_and_version(level, version)
+    set_level_and_version(level, version, report_severities = ["Fatal", "Error"])
 
 A converter to pass into [`readSBML`](@ref) that enforces certain SBML level
-and version.
+and version.  `report_severities` switches on and off reporting of certain
+errors; see the documentation of [`get_error_messages`](@ref) for details.
 """
-set_level_and_version(level, version) =
+set_level_and_version(level, version, report_severities = ["Fatal", "Error"]) =
     doc -> check_errors(
         ccall(
             sbml(:SBMLDocument_setLevelAndVersion),
@@ -17,17 +18,20 @@ set_level_and_version(level, version) =
         ),
         doc,
         ErrorException("Setting of level and version did not succeed"),
+        report_severities,
     )
 
 """
-    libsbml_convert(conversion_options::Vector{Pair{String, Dict{String, String}}})
+    libsbml_convert(conversion_options::Vector{Pair{String, Dict{String, String}}}, report_severities = ["Fatal", "Error"])
 
 A converter that runs the SBML conversion routine, with specified conversion
 options. The argument is a vector of pairs to allow specifying the order of
-conversions.
+conversions.  `report_severities` switches on and off reporting of certain
+errors; see the documentation of [`get_error_messages`](@ref) for details.
 """
 libsbml_convert(
     conversion_options::AbstractVector{<:Pair{String,<:AbstractDict{String,String}}},
+    report_severities = ["Fatal", "Error"],
 ) =
     doc -> begin
         for (converter, options) in conversion_options
@@ -51,23 +55,28 @@ libsbml_convert(
                 iszero(ccall(sbml(:SBMLDocument_convert), Cint, (VPtr, VPtr), doc, props)),
                 doc,
                 ErrorException("Conversion returned errors"),
+                report_severities,
             )
         end
     end
 
 """
-    libsbml_convert(converter::String; kwargs...)
+    libsbml_convert(converter::String, report_severities = ["Fatal", "Error"]; kwargs...)
 
 Quickly construct a single run of a `libsbml` converter from keyword arguments.
+`report_severities` switches on and off reporting of certain errors; see the
+documentation of [`get_error_messages`](@ref) for details.
 
 # Example
 ```
 readSBML("example.xml", libsbml_convert("stripPackage", package="layout"))
 ```
 """
-libsbml_convert(converter::String; kwargs...) = libsbml_convert([
-    converter => Dict{String,String}(string(k) => string(v) for (k, v) in kwargs),
-])
+libsbml_convert(converter::String, report_severities = ["Fatal", "Error"]; kwargs...) =
+    libsbml_convert([
+        converter => Dict{String,String}(string(k) => string(v) for (k, v) in kwargs),
+    ],
+                    report_severities)
 
 """
     convert_simplify_math

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -64,6 +64,14 @@ sbmlfiles = [
         4,
         2,
     ),
+    # expandInitialAssignments converter gives some warning
+    (
+        joinpath(@__DIR__, "data", "01234-sbml-l3v2.xml"),
+        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/52d94baf97a005b6e1fdbdb6116f5c7b4a8a100c/cases/semantic/01234/01234-sbml-l3v2.xml",
+        "9610ef29f2d767af627042a15bde505b068ab75bbf00b8983823800ea8ef67c8",
+        0,
+        0,
+    ),
 ]
 
 @testset "Loading of models from various sources" begin
@@ -170,6 +178,10 @@ end
 
     @test test_math.args[2].fn == "sin"
     @test test_math.args[2].args[1].val == 2.1
+
+    @test_logs (:warn,) (:warn,) (:warn,) (:warn,) readSBML(joinpath(@__DIR__, "data", "01234-sbml-l3v2.xml"),
+             doc -> libsbml_convert("expandInitialAssignments", ["Fatal", "Error", "Warning"])(doc)
+             )
 end
 
 @testset "relational operators are decoded correctly" begin


### PR DESCRIPTION
Related to #125, we weren't forwarding `report_severities` to `check_errors`, so
there was no way to actually see the warning.

Note: this depends on #126, but I opened it as a separate pull request because I
think it's logically independent from that one.