### PR TITLE
checking `isfile(fn)` in _readSBML

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -77,6 +77,7 @@ function _readSBML(
     sbml_conversion,
     report_severities,
 )::SBML.Model
+    !isfile(fn) && error("$fn is not a file")
     doc = ccall(sbml(symbol), VPtr, (Cstring,), fn)
     try
         get_error_messages(


### PR DESCRIPTION
I think this provides an easier to interpret error. 
Not sure if this is the right way to do this but

```julia 
┌ Error: SBML reported error: File unreadable.
└ @ SBML C:\Users\Anand\.julia\packages\SBML\mEjXV\src\utils.jl:163
ERROR: LoadError: AssertionError: Opening SBML document has reported errors
```
"File unreadable" is pretty opaque to me. It makes me think the file is corrupted or something. 
9/10 times it's that I gave the wrong filename.

I remember asking for this earlier but couldn't find it.