### PR TITLE
Make `sbml` slightly more type-stable

### DIFF
--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -21,7 +21,7 @@ include("readsbml.jl")
 include("symbolics.jl")
 include("utils.jl")
 
-sbml(sym::Symbol) = dlsym(SBML_jll.libsbml_handle, sym)
+sbml(sym::Symbol)::VPtr = dlsym(SBML_jll.libsbml_handle, sym)
 
 export readSBML, readSBMLFromString, stoichiometry_matrix, flux_bounds, flux_objective
 export set_level_and_version, libsbml_convert, convert_simplify_math


### PR DESCRIPTION
`Libdl.dlsym` can return `Union{Nothing, Ptr{Nothing}}`.  We know that the
symbols we use exist, and even if they didn't this change makes the function
fail early instead of calling a `NULL` function in the shared library :boom: