### PR TITLE
Fix definition of units

### DIFF
--- a/test/ecoli_flux.jl
+++ b/test/ecoli_flux.jl
@@ -22,7 +22,7 @@ end
         sbmlfile * ".does.not.really.exist",
     )
 
-    @test mdl.units["mmol_per_gDW_per_hr"] == 2.7777e-7 * u"mol * g^-1 * s^-1"
+    @test mdl.units["mmol_per_gDW_per_hr"] ≈ 3.6001008028224795 * u"mol * g^-1 * s^-1"
 
     @test length(mdl.compartments) == 2
 


### PR DESCRIPTION
The exponent applies to the multiplier as well.  Reorganize the `get_unit`
function to make it clearer what's the formula used.