### PR TITLE
simplify stoichiometry_matrix API & make it more efficient

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -272,7 +272,7 @@ function get_unit(u::VPtr)
     exponent = ccall(sbml(:Unit_getExponent), Cint, (VPtr,), u)
     # See page 44 of
     # http://sbml.org/Special/specifications/sbml-level-3/version-2/core/release-2/sbml-level-3-version-2-release-2-core.pdf
-    return (multiplier * unit * exp10(scale)) ^ exponent
+    return (multiplier * unit * exp10(scale))^exponent
 end
 
 # Get `Unitful` quantity out of a `UnitDefinition_t`.

--- a/test/ecoli_flux.jl
+++ b/test/ecoli_flux.jl
@@ -28,9 +28,7 @@ end
 
     mets, rxns, S = stoichiometry_matrix(mdl)
 
-    @test typeof(S) <: AbstractMatrix{Float64}
-    @test typeof(stoichiometry_matrix(mdl; zeros = spzeros)[3]) <: SparseMatrixCSC{Float64}
-    @test typeof(stoichiometry_matrix(mdl; zeros = zeros)[3]) == Matrix{Float64}
+    @test typeof(S) <: SparseMatrixCSC{Float64}
 
     @test length(mets) == 77
     @test length(rxns) == 77


### PR DESCRIPTION
Writing individual fields to sparse matrices is pretty slow, this should be faster in most cases. More or less a consequence of https://github.com/LCSB-BioCore/COBREXA.jl/pull/443 .
