### PR TITLE
load units annotations from Model_t

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -576,6 +576,12 @@ function extract_model(mdl::VPtr)::SBML.Model
         gene_products,
         function_definitions,
         events,
+        area_units = get_optional_string(mdl, :Model_getAreaUnits),
+        extent_units = get_optional_string(mdl, :Model_getExtentUnits),
+        length_units = get_optional_string(mdl, :Model_getLengthUnits),
+        substance_units = get_optional_string(mdl, :Model_getSubstanceUnits),
+        time_units = get_optional_string(mdl, :Model_getTimeUnits),
+        volume_units = get_optional_string(mdl, :Model_getVolumeUnits),
         notes = get_notes(mdl),
         annotation = get_annotation(mdl),
     )

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -292,6 +292,12 @@ Base.@kwdef struct Model
     gene_products::Dict{String,GeneProduct} = Dict()
     function_definitions::Dict{String,FunctionDefinition} = Dict()
     events::Dict{String,Event} = Dict()
+    area_units::Maybe{String} = nothing
+    extent_units::Maybe{String} = nothing
+    length_units::Maybe{String} = nothing
+    substance_units::Maybe{String} = nothing
+    time_units::Maybe{String} = nothing
+    volume_units::Maybe{String} = nothing
     notes::Maybe{String} = nothing
     annotation::Maybe{String} = nothing
 end

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -107,6 +107,15 @@ sbmlfiles = [
         0,
         Float64[],
     ),
+    # has all kinds of default model units
+    (
+        joinpath(@__DIR__, "data", "00054-sbml-l3v2.xml"),
+        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00054/00054-sbml-l3v2.xml",
+        "987038ec9bb847123c41136928462d7ed05ad697cc414cab09fcce9f5bbc8e73",
+        3,
+        2,
+        fill(Inf,2),
+    ),
 ]
 
 @testset "Loading of models from various sources - $(reader)" for reader in (
@@ -327,4 +336,14 @@ end
 @testset "events" begin
     m = readSBML(joinpath(@__DIR__, "data", "00026-sbml-l3v2.xml"))
     @test length(m.events) == 1
+end
+
+@testset "model units" begin
+    m = readSBML(joinpath(@__DIR__, "data", "00054-sbml-l3v2.xml"))
+    @test m.area_units == "area"
+    @test m.extent_units == "substance"
+    @test m.length_units == "metre"
+    @test m.substance_units == "substance"
+    @test m.time_units == "second"
+    @test m.volume_units == "volume"
 end


### PR DESCRIPTION
Apparently there are "defaulted" units accessible from Model_t structure. Thanks @anandijain for pointing out.