### PR TITLE
Clean up the parameter handling

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -110,7 +110,7 @@ function _readSBML(
 
         model = ccall(sbml(:SBMLDocument_getModel), VPtr, (VPtr,), doc)
 
-        return extract_model(model)
+        return get_model(model)
     finally
         ccall(sbml(:SBMLDocument_free), Nothing, (VPtr,), doc)
     end
@@ -203,7 +203,7 @@ function get_association(x::VPtr)::GeneProductAssociation
     end
 end
 
-extract_parameter(p::VPtr)::Pair{String,Parameter} =
+get_parameter(p::VPtr)::Pair{String,Parameter} =
     get_string(p, :Parameter_getId) => Parameter(
         name = get_optional_string(p, :Parameter_getName),
         value = ccall(sbml(:Parameter_getValue), Cdouble, (VPtr,), p),
@@ -212,12 +212,12 @@ extract_parameter(p::VPtr)::Pair{String,Parameter} =
     )
 
 """"
-    function extract_model(mdl::VPtr)::SBML.Model
+    function get_model(mdl::VPtr)::SBML.Model
 
 Take the `SBMLModel_t` pointer and extract all information required to make a
 valid [`SBML.Model`](@ref) structure.
 """
-function extract_model(mdl::VPtr)::SBML.Model
+function get_model(mdl::VPtr)::SBML.Model
     # get the FBC plugin pointer (FbcModelPlugin_t)
     mdl_fbc = ccall(sbml(:SBase_getPlugin), VPtr, (VPtr, Cstring), mdl, "fbc")
 
@@ -225,7 +225,7 @@ function extract_model(mdl::VPtr)::SBML.Model
     parameters = Dict{String,Parameter}()
     for i = 1:ccall(sbml(:Model_getNumParameters), Cuint, (VPtr,), mdl)
         p = ccall(sbml(:Model_getParameter), VPtr, (VPtr, Cuint), mdl, i - 1)
-        id, v = extract_parameter(p)
+        id, v = get_parameter(p)
         parameters[id] = v
     end
 
@@ -365,7 +365,7 @@ function extract_model(mdl::VPtr)::SBML.Model
         if kl != C_NULL
             for j = 1:ccall(sbml(:KineticLaw_getNumParameters), Cuint, (VPtr,), kl)
                 p = ccall(sbml(:KineticLaw_getParameter), VPtr, (VPtr, Cuint), kl, j - 1)
-                id, v = extract_parameter(p)
+                id, v = get_parameter(p)
                 parameters[id] = v
                 kinetic_parameters[id] = v
             end

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -293,22 +293,6 @@ function get_model(mdl::VPtr)::SBML.Model
             end
         end
 
-        ia = nothing
-        if ccall(sbml(:Species_isSetInitialAmount), Cint, (VPtr,), sp) != 0
-            ia = (
-                ccall(sbml(:Species_getInitialAmount), Cdouble, (VPtr,), sp),
-                get_optional_string(sp, :Species_getSubstanceUnits),
-            )
-        end
-
-        ic = nothing
-        if ccall(sbml(:Species_isSetInitialConcentration), Cint, (VPtr,), sp) != 0
-            ic = (
-                ccall(sbml(:Species_getInitialConcentration), Cdouble, (VPtr,), sp),
-                get_optional_string(sp, :Species_getSubstanceUnits),
-            )
-        end
-
         species[get_string(sp, :Species_getId)] = Species(
             get_optional_string(sp, :Species_getName),
             get_string(sp, :Species_getCompartment),
@@ -319,8 +303,13 @@ function get_model(mdl::VPtr)::SBML.Model
             ),
             formula,
             charge,
-            ia,
-            ic,
+            if (ccall(sbml(:Species_isSetInitialAmount), Cint, (VPtr,), sp) != 0)
+                ccall(sbml(:Species_getInitialAmount), Cdouble, (VPtr,), sp)
+            end,
+            if (ccall(sbml(:Species_isSetInitialConcentration), Cint, (VPtr,), sp) != 0)
+                ccall(sbml(:Species_getInitialConcentration), Cdouble, (VPtr,), sp)
+            end,
+            get_optional_string(sp, :Species_getSubstanceUnits),
             get_optional_bool(
                 sp,
                 :Species_isSetHasOnlySubstanceUnits,

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -147,7 +147,7 @@ end)
 function readSBML(
     fn::String,
     sbml_conversion = document -> nothing;
-    report_severities = ["Fatal", "Error"]
+    report_severities = ["Fatal", "Error"],
 )::SBML.Model
     isfile(fn) || throw(AssertionError("$(fn) is not a file"))
     _readSBML(:readSBML, fn, sbml_conversion, report_severities)
@@ -167,7 +167,7 @@ used to read from a file instead of a string.
 readSBMLFromString(
     str::AbstractString,
     sbml_conversion = document -> nothing;
-    report_severities = ["Fatal", "Error"]
+    report_severities = ["Fatal", "Error"],
 )::SBML.Model =
     _readSBML(:readSBMLFromString, String(str), sbml_conversion, report_severities)
 
@@ -203,11 +203,11 @@ function get_association(x::VPtr)::GeneProductAssociation
     end
 end
 
-extract_parameter(p::VPtr)::Pair{String, Parameter} =
+extract_parameter(p::VPtr)::Pair{String,Parameter} =
     get_string(p, :Parameter_getId) => Parameter(
         name = get_optional_string(p, :Parameter_getName),
         value = ccall(sbml(:Parameter_getValue), Cdouble, (VPtr,), p),
-        units = get_optional_string(p, :Parameter_getUnits), 
+        units = get_optional_string(p, :Parameter_getUnits),
         constant = get_optional_bool(p, :Parameter_isSetConstant, :Parameter_getConstant),
     )
 
@@ -431,7 +431,7 @@ function extract_model(mdl::VPtr)::SBML.Model
             kinetic_math = math,
             reversible,
             notes = get_notes(re),
-            annotation = get_annotation(re)
+            annotation = get_annotation(re),
         )
     end
 
@@ -588,6 +588,6 @@ function extract_model(mdl::VPtr)::SBML.Model
         time_units = get_optional_string(mdl, :Model_getTimeUnits),
         volume_units = get_optional_string(mdl, :Model_getVolumeUnits),
         notes = get_notes(mdl),
-        annotation = get_annotation(mdl)
+        annotation = get_annotation(mdl),
     )
 end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -100,6 +100,20 @@ end
 """
 $(TYPEDEF)
 
+# Fields
+$(TYPEDFIELDS)
+"""
+Base.@kwdef struct Parameter
+    # id::String
+    name::Maybe{String} = nothing
+    value::Maybe{Float64} = nothing
+    units::Maybe{String} = nothing
+    constant::Bool
+end
+
+"""
+$(TYPEDEF)
+
 SBML Compartment with sizing information.
 
 # Fields
@@ -129,7 +143,7 @@ $(TYPEDFIELDS)
 Base.@kwdef struct Reaction
     reactants::Dict{String,Float64} = Dict()
     products::Dict{String,Float64} = Dict()
-    kinetic_parameters::Dict{String,Tuple{Float64,String}} = Dict()
+    kinetic_parameters::Dict{String,Parameter} = Dict()
     lower_bound::Maybe{String} = nothing
     upper_bound::Maybe{String} = nothing
     gene_product_association::Maybe{GeneProductAssociation} = nothing
@@ -280,7 +294,7 @@ objects.
 $(TYPEDFIELDS)
 """
 Base.@kwdef struct Model
-    parameters::Dict{String,Tuple{Float64,String}} = Dict()
+    parameters::Dict{String,Parameter} = Dict()
     units::Dict{String,Vector{UnitPart}} = Dict()
     compartments::Dict{String,Compartment} = Dict()
     species::Dict{String,Species} = Dict()

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -107,7 +107,7 @@ Base.@kwdef struct Parameter
     name::Maybe{String} = nothing
     value::Maybe{Float64} = nothing
     units::Maybe{String} = nothing
-    constant::Bool
+    constant::Maybe{Bool} = nothing
 end
 
 """

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -228,8 +228,9 @@ Base.@kwdef struct Species
     boundary_condition::Maybe{Bool} = nothing
     formula::Maybe{String} = nothing
     charge::Maybe{Int} = nothing
-    initial_amount::Maybe{Tuple{Float64,Maybe{String}}} = nothing
-    initial_concentration::Maybe{Tuple{Float64,Maybe{String}}} = nothing
+    initial_amount::Maybe{Float64} = nothing
+    initial_concentration::Maybe{Float64} = nothing
+    substance_units::Maybe{String} = nothing
     only_substance_units::Maybe{Bool} = nothing
     notes::Maybe{String} = nothing
     annotation::Maybe{String} = nothing

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -100,6 +100,9 @@ end
 """
 $(TYPEDEF)
 
+Representation of SBML Parameter structure, holding a value annotated with
+units and constantness information.
+
 # Fields
 $(TYPEDFIELDS)
 """

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -104,7 +104,6 @@ $(TYPEDEF)
 $(TYPEDFIELDS)
 """
 Base.@kwdef struct Parameter
-    # id::String
     name::Maybe{String} = nothing
     value::Maybe{Float64} = nothing
     units::Maybe{String} = nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -63,9 +63,9 @@ function flux_bounds(m::SBML.Model)::NTuple{2,Vector{Tuple{Float64,String}}}
     # We extract these, using the units from the parameters. For unbounded
     # reactions this gives -Inf or Inf as a default.
     function param_to_tuple(p)
-        if p.units === nothing 
+        if p.units === nothing
             (p.value, "")
-        else 
+        else
             (p.value, p.units)
         end
     end
@@ -94,15 +94,8 @@ function flux_objective(m::SBML.Model)::Vector{Float64}
     # even more). FBC-specified OC gets a priority.
     function get_oc(rid::String)
         p = get(m.reactions[rid].kinetic_parameters, "OBJECTIVE_COEFFICIENT", nothing)
-        t = p !==nothing ? (p.value, p.units) : nothing
-        mayfirst(
-            get(m.objective, rid, nothing),
-            maylift(
-                first,
-                t
-            ),
-            0.0,
-        )
+        t = p !== nothing ? (p.value, p.units) : nothing
+        mayfirst(get(m.objective, rid, nothing), maylift(first, t), 0.0)
     end
     get_oc.(keys(m.reactions))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -146,7 +146,8 @@ available. If `convert_concentrations` is true and there is information about
 initial concentration available together with compartment size, the result is
 computed from the species' initial concentration.
 
-In the current version, units of the measurements are completely ignored.
+The units of measurement are ignored in this computation, but one may
+reconstruct them from `substance_units` field of [`Species`](@ref) structure.
 
 # Example
 ```
@@ -173,7 +174,7 @@ initial_amounts(
         maylift(first, s.initial_amount),
         if convert_concentrations
             maylift(
-                (ic, s) -> first(ic) * s,
+                (ic, s) -> ic * s,
                 s.initial_concentration,
                 compartment_size(s.compartment),
             )
@@ -199,11 +200,7 @@ initial_concentrations(
     k => mayfirst(
         maylift(first, s.initial_concentration),
         if convert_amounts
-            maylift(
-                (ia, s) -> first(ia) / s,
-                s.initial_amount,
-                compartment_size(s.compartment),
-            )
+            maylift((ia, s) -> ia / s, s.initial_amount, compartment_size(s.compartment))
         end,
     ) for (k, s) in m.species
 )

--- a/test/loaddynamicmodels.jl
+++ b/test/loaddynamicmodels.jl
@@ -86,9 +86,9 @@ sbmlfiles = [
             if basename(sbmlfile) == "00037-sbml-l3v2.xml"
                 # When expanding initial assignments with libsbml, the initial amount
                 # becomes empty.
-                @test_broken mdl.species[id].initial_amount[1] == ic
+                @test_broken mdl.species[id].initial_amount == ic
             else
-                @test mdl.species[id].initial_amount[1] == ic
+                @test mdl.species[id].initial_amount == ic
             end
         end
     end

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -114,7 +114,7 @@ sbmlfiles = [
         "987038ec9bb847123c41136928462d7ed05ad697cc414cab09fcce9f5bbc8e73",
         3,
         2,
-        fill(Inf,2),
+        fill(Inf, 2),
     ),
     # has conversionFactor model attribute
     (
@@ -123,7 +123,7 @@ sbmlfiles = [
         "e32c12b7bebfa8f146b8860cd8b82d5cad326c96c6a0d8ceb191591ac4e2f5ac",
         2,
         3,
-        fill(Inf,3),
+        fill(Inf, 3),
     ),
 ]
 


### PR DESCRIPTION
This includes AJ's commits from #181 which is thus deprecated. Parameters are thus materialized with constantness status, names and proper units. Breaks compatibility with software that creates the old Parameter tuples directly (COBREXA).

Also closes #181.