### PR TITLE
separate substance units from initial amounts and concentrations

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -293,22 +293,6 @@ function get_model(mdl::VPtr)::SBML.Model
             end
         end
 
-        ia = nothing
-        if ccall(sbml(:Species_isSetInitialAmount), Cint, (VPtr,), sp) != 0
-            ia = (
-                ccall(sbml(:Species_getInitialAmount), Cdouble, (VPtr,), sp),
-                get_optional_string(sp, :Species_getSubstanceUnits),
-            )
-        end
-
-        ic = nothing
-        if ccall(sbml(:Species_isSetInitialConcentration), Cint, (VPtr,), sp) != 0
-            ic = (
-                ccall(sbml(:Species_getInitialConcentration), Cdouble, (VPtr,), sp),
-                get_optional_string(sp, :Species_getSubstanceUnits),
-            )
-        end
-
         species[get_string(sp, :Species_getId)] = Species(
             get_optional_string(sp, :Species_getName),
             get_string(sp, :Species_getCompartment),
@@ -319,8 +303,13 @@ function get_model(mdl::VPtr)::SBML.Model
             ),
             formula,
             charge,
-            ia,
-            ic,
+            if (ccall(sbml(:Species_isSetInitialAmount), Cint, (VPtr,), sp) != 0)
+                ccall(sbml(:Species_getInitialAmount), Cdouble, (VPtr,), sp)
+            end,
+            if (ccall(sbml(:Species_isSetInitialConcentration), Cint, (VPtr,), sp) != 0)
+                ccall(sbml(:Species_getInitialConcentration), Cdouble, (VPtr,), sp)
+            end,
+            get_optional_string(sp, :Species_getSubstanceUnits),
             get_optional_bool(
                 sp,
                 :Species_isSetHasOnlySubstanceUnits,

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -225,8 +225,9 @@ Base.@kwdef struct Species
     boundary_condition::Maybe{Bool} = nothing
     formula::Maybe{String} = nothing
     charge::Maybe{Int} = nothing
-    initial_amount::Maybe{Tuple{Float64,Maybe{String}}} = nothing
-    initial_concentration::Maybe{Tuple{Float64,Maybe{String}}} = nothing
+    initial_amount::Maybe{Float64} = nothing
+    initial_concentration::Maybe{Float64} = nothing
+    substance_units::Maybe{String} = nothing
     only_substance_units::Maybe{Bool} = nothing
     notes::Maybe{String} = nothing
     annotation::Maybe{String} = nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -146,7 +146,8 @@ available. If `convert_concentrations` is true and there is information about
 initial concentration available together with compartment size, the result is
 computed from the species' initial concentration.
 
-In the current version, units of the measurements are completely ignored.
+The units of measurement are ignored in this computation, but one may
+reconstruct them from `substance_units` field of [`Species`](@ref) structure.
 
 # Example
 ```
@@ -173,7 +174,7 @@ initial_amounts(
         maylift(first, s.initial_amount),
         if convert_concentrations
             maylift(
-                (ic, s) -> first(ic) * s,
+                (ic, s) -> ic * s,
                 s.initial_concentration,
                 compartment_size(s.compartment),
             )
@@ -199,11 +200,7 @@ initial_concentrations(
     k => mayfirst(
         maylift(first, s.initial_concentration),
         if convert_amounts
-            maylift(
-                (ia, s) -> first(ia) / s,
-                s.initial_amount,
-                compartment_size(s.compartment),
-            )
+            maylift((ia, s) -> ia / s, s.initial_amount, compartment_size(s.compartment))
         end,
     ) for (k, s) in m.species
 )

--- a/test/loaddynamicmodels.jl
+++ b/test/loaddynamicmodels.jl
@@ -86,9 +86,9 @@ sbmlfiles = [
             if basename(sbmlfile) == "00037-sbml-l3v2.xml"
                 # When expanding initial assignments with libsbml, the initial amount
                 # becomes empty.
-                @test_broken mdl.species[id].initial_amount[1] == ic
+                @test_broken mdl.species[id].initial_amount == ic
             else
-                @test mdl.species[id].initial_amount[1] == ic
+                @test mdl.species[id].initial_amount == ic
             end
         end
     end


### PR DESCRIPTION
SBML has the substance units only once, in `Species_t`.

Code was developed atop #182 so I base it on that branch.