### PR TITLE
Avoid using `eval`

### DIFF
--- a/src/symbolics.jl
+++ b/src/symbolics.jl
@@ -129,7 +129,7 @@ function Base.convert(
     end,
     convert_const = (x::SBML.MathConst) -> Num(default_symbolics_constants[x.id]),
 )
-    conv(x::SBML.MathApply) = Num(eval(allowed_sym(x.fn, mapping))(conv.(x.args)...))
+    conv(x::SBML.MathApply) = Num(getfield(SBML, allowed_sym(x.fn, mapping))(conv.(x.args)...))
     conv(x::SBML.MathTime) = convert_time(x)
     conv(x::SBML.MathConst) = convert_const(x)
     function conv(x::SBML.MathIdent)


### PR DESCRIPTION
NOTE: this requires the functions in `mapping` to be accessible from `SBML`.  This is true for the functions in `default_symbolics_mapping`, but if the users passes something else, that's going to go boom.

CC: @anandijain 