### PR TITLE
Add precompilation statement for `readSBML`

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -590,3 +590,6 @@ function get_model(mdl::VPtr)::SBML.Model
         annotation = get_annotation(mdl),
     )
 end
+
+# Precompilation statements
+precompile(readSBML, (String,))


### PR DESCRIPTION
Currently on `master`:
```
% julia --startup-file=no -q
julia> @time @eval using SBML
  7.097549 seconds (17.01 M allocations: 1.103 GiB, 4.97% gc time, 27.18% compilation time)

julia> @time @eval m = readSBML(joinpath(dirname(dirname(pathof(SBML))), "test", "data", "Dasgupta2020.xml"))
  5.133433 seconds (19.02 M allocations: 999.460 MiB, 8.43% gc time, 99.74% compilation time)
SBML.Model with 6 reactions, 2 species, and 8 parameters.

julia> @time @eval m = readSBML(joinpath(dirname(dirname(pathof(SBML))), "test", "data", "Dasgupta2020.xml"))
  0.004888 seconds (1.61 k allocations: 81.672 KiB)
SBML.Model with 6 reactions, 2 species, and 8 parameters.
```

With this PR:
```
% julia --project=/tmp --startup-file=no -q
julia> @time @eval using SBML
  7.163278 seconds (17.19 M allocations: 1.116 GiB, 4.83% gc time, 27.06% compilation time)

julia> @time @eval m = readSBML(joinpath(dirname(dirname(pathof(SBML))), "test", "data", "Dasgupta2020.xml"))
  2.407181 seconds (3.23 M allocations: 202.814 MiB, 12.68% gc time, 99.36% compilation time)
SBML.Model with 6 reactions, 2 species, and 8 parameters.

julia> @time @eval m = readSBML(joinpath(dirname(dirname(pathof(SBML))), "test", "data", "Dasgupta2020.xml"))
  0.004769 seconds (2.43 k allocations: 94.797 KiB)
SBML.Model with 6 reactions, 2 species, and 8 parameters.
```

I guess shaving off a couple of seconds from time-to-first `readSBML` isn't too bad :slightly_smiling_face:   The cost is 3-4 more seconds of precompilation time, but that's a one-off when the package is updated.