### PR TITLE
Read also name of unit definitions

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -235,7 +235,7 @@ function get_model(mdl::VPtr)::SBML.Model
         ud = ccall(sbml(:Model_getUnitDefinition), VPtr, (VPtr, Cuint), mdl, i - 1)
         id = get_string(ud, :UnitDefinition_getId)
         name = get_optional_string(ud, :UnitDefinition_getName)
-        list_of_units = [
+        unit_parts = [
             begin
                 u = ccall(sbml(:UnitDefinition_getUnit), VPtr, (VPtr, Cuint), ud, j - 1)
                 SBML.UnitPart(
@@ -253,7 +253,7 @@ function get_model(mdl::VPtr)::SBML.Model
                 )
             end for j = 1:ccall(sbml(:UnitDefinition_getNumUnits), Cuint, (VPtr,), ud)
         ]
-        units[id] = UnitDefinition(; name, list_of_units)
+        units[id] = UnitDefinition(; name, unit_parts)
     end
 
     # parse out compartment names

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -230,11 +230,12 @@ function get_model(mdl::VPtr)::SBML.Model
     end
 
     # parse out the unit definitions
-    units = Dict{String,Vector{SBML.UnitPart}}()
+    units = Dict{String,UnitDefinition}()
     for i = 1:ccall(sbml(:Model_getNumUnitDefinitions), Cuint, (VPtr,), mdl)
         ud = ccall(sbml(:Model_getUnitDefinition), VPtr, (VPtr, Cuint), mdl, i - 1)
         id = get_string(ud, :UnitDefinition_getId)
-        units[id] = [
+        name = get_optional_string(ud, :UnitDefinition_getName)
+        list_of_units = [
             begin
                 u = ccall(sbml(:UnitDefinition_getUnit), VPtr, (VPtr, Cuint), ud, j - 1)
                 SBML.UnitPart(
@@ -252,6 +253,7 @@ function get_model(mdl::VPtr)::SBML.Model
                 )
             end for j = 1:ccall(sbml(:UnitDefinition_getNumUnits), Cuint, (VPtr,), ud)
         ]
+        units[id] = UnitDefinition(; name, list_of_units)
     end
 
     # parse out compartment names

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -21,7 +21,7 @@ end
 
 Base.@kwdef struct UnitDefinition
     name::Maybe{String} = nothing
-    list_of_units::Vector{UnitPart}
+    unit_parts::Vector{UnitPart}
 end
 
 

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -19,6 +19,11 @@ Base.@kwdef struct UnitPart
     multiplier::Float64
 end
 
+Base.@kwdef struct UnitDefinition
+    name::Maybe{String} = nothing
+    list_of_units::Vector{UnitPart}
+end
+
 
 """
 Abstract type for all kinds of gene product associations
@@ -300,7 +305,7 @@ $(TYPEDFIELDS)
 """
 Base.@kwdef struct Model
     parameters::Dict{String,Parameter} = Dict()
-    units::Dict{String,Vector{UnitPart}} = Dict()
+    units::Dict{String,UnitDefinition} = Dict()
     compartments::Dict{String,Compartment} = Dict()
     species::Dict{String,Species} = Dict()
     initial_assignments::Dict{String,Math} = Dict()

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -9,8 +9,7 @@ of `Unit`. For example, the unit "per square megahour", Mh^(-2), is written as:
              1/3600)    # second-to-hour multiplier
 
 Compound units (such as "volt-amperes" and "dozens of yards per ounce") are
-built from multiple `UnitPart`s; see the definition of field `units` in
-[`SBML.Model`](@ref).
+built from multiple `UnitPart`s.  See also [`SBML.UnitDefinition`](@ref).
 """
 Base.@kwdef struct UnitPart
     kind::String
@@ -19,6 +18,16 @@ Base.@kwdef struct UnitPart
     multiplier::Float64
 end
 
+"""
+$(TYPEDEF)
+
+Representation of SBML unit definition, holding the name of the unit and a
+vector of [`SBML.UnitPart`](@ref)s.  See the definition of field `units` in
+[`SBML.Model`](@ref).
+
+# Fields
+$(TYPEDFIELDS)
+"""
 Base.@kwdef struct UnitDefinition
     name::Maybe{String} = nothing
     unit_parts::Vector{UnitPart}

--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -43,7 +43,7 @@ const UNITFUL_KIND_STRING = Dict(
 )
 
 
-unitful(u::UnitDefinition) = unitful(u.list_of_units)
+unitful(u::UnitDefinition) = unitful(u.unit_parts)
 
 """
     unitful(u::UnitPart)

--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -43,12 +43,18 @@ const UNITFUL_KIND_STRING = Dict(
 )
 
 
+"""
+    unitful(units::UnitDefinition)
+
+Converts an SBML unit definition (i.e., its vector of [`UnitPart`](@ref)s) to a
+corresponding Unitful unit.
+"""
 unitful(u::UnitDefinition) = unitful(u.unit_parts)
 
 """
     unitful(u::UnitPart)
 
-Converts an [`UnitPart`](@ref) to a corresponding Unitful unit.
+Converts a [`UnitPart`](@ref) to a corresponding Unitful unit.
 
 The conversion is done according to the formula from
 [SBML L3v2 core manual release 2](http://sbml.org/Special/specifications/sbml-level-3/version-2/core/release-2/sbml-level-3-version-2-release-2-core.pdf)(section 4.4.2).
@@ -59,7 +65,7 @@ unitful(u::UnitPart) =
 """
     unitful(units::Vector{UnitPart})
 
-Converts a SBML unit (i.e., a vector of [`UnitPart`](@ref)s) to a corresponding
+Converts an SBML unit (i.e., a vector of [`UnitPart`](@ref)s) to a corresponding
 Unitful unit.
 """
 unitful(u::Vector{UnitPart}) = prod(unitful.(u))

--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -43,6 +43,8 @@ const UNITFUL_KIND_STRING = Dict(
 )
 
 
+unitful(u::UnitDefinition) = unitful(u.list_of_units)
+
 """
     unitful(u::UnitPart)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -325,3 +325,5 @@ Base.:(==)(a::AlgebraicRule, b::AlgebraicRule) = a.math == b.math
 Base.:(==)(a::T, b::T) where {T<:Union{AssignmentRule,RateRule}} =
     a.id == b.id && a.math == b.math
 Base.:(==)(a::Constraint, b::Constraint) = a.math == b.math && a.message == b.message
+Base.:(==)(a::UnitDefinition, b::UnitDefinition) =
+    a.name == b.name && a.list_of_units == b.list_of_units

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -326,4 +326,4 @@ Base.:(==)(a::T, b::T) where {T<:Union{AssignmentRule,RateRule}} =
     a.id == b.id && a.math == b.math
 Base.:(==)(a::Constraint, b::Constraint) = a.math == b.math && a.message == b.message
 Base.:(==)(a::UnitDefinition, b::UnitDefinition) =
-    a.name == b.name && a.list_of_units == b.list_of_units
+    a.name == b.name && a.unit_parts == b.unit_parts


### PR DESCRIPTION
This is an optional property and it's usually the same as the ID, reason why I
initially skipped it, but it may be useful to store this information as well for
consistency with the SBML format.

I noticed this while working on #143: by comparing the original file and the one we write there was this property missing.

Note: at the moment this is missing docstrings, will add them if this is deemed useful.
Note 2: this is a potentially breaking change as it modifies the layout of `Model`.