### PR TITLE
extensive math correctly exposes compartment identifications

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -119,20 +119,20 @@ their own definition of `rateOf` that uses the correct derivative.
 """
 function interpret_math(
     x::SBML.Math;
-    map_apply = (fn::String, args, interpret::Function) ->
-        SBML.default_function_mapping[fn](interpret.(args)...),
+    map_apply = (x::SBML.MathApply, interpret::Function) ->
+        SBML.default_function_mapping[x.fn](interpret.(x.args)...),
     map_const = (x::SBML.MathConst) -> default_constants[x.id],
     map_ident = (x::SBML.MathIdent) ->
         throw(ErrorException("identifier mapping not defined")),
-    map_lambda = (x::SBML.MathLambda) ->
+    map_lambda = (x::SBML.MathLambda, interpret::Function) ->
         throw(ErrorException("lambda function mapping not defined")),
     map_time = (x::SBML.MathTime) -> throw(ErrorException("time mapping not defined")),
     map_value = (x::SBML.MathVal) -> x.val,
 )
-    interpret(x::SBML.MathApply) = map_apply(x.fn, x.args, interpret)
+    interpret(x::SBML.MathApply) = map_apply(x, interpret)
     interpret(x::SBML.MathConst) = map_const(x)
     interpret(x::SBML.MathIdent) = map_ident(x)
-    interpret(x::SBML.MathLambda) = map_lambda(x)
+    interpret(x::SBML.MathLambda) = map_lambda(x, interpret)
     interpret(x::SBML.MathTime) = map_time(x)
     interpret(x::SBML.MathVal) = map_value(x)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -257,8 +257,7 @@ function extensive_kinetic_math(
         haskey(m.species, x.id) || return x
         sp = m.species[x.id]
         sp.only_substance_units && return x
-        # sz = m.compartments[sp.compartment].size
-        # isnothing(sz) && (sz = handle_empty_compartment_size(x.id))
+        m.compartments[sp.compartment].spatial_dimensions == 0 && return x
         hassize(sp.compartment, m) || handle_empty_compartment_size(x.id)
         SBML.MathApply("/", [x, SBML.MathIdent(sp.compartment)])
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -131,8 +131,13 @@ maylift(f, args::Maybe...) = any(isnothing, args) ? nothing : f(args...)
 A helper for easily getting out a defaulted compartment size.
 """
 get_compartment_size(m::SBML.Model, compartment; default = nothing) =
-    mayfirst(maylift(x -> x.spatial_dimensions == 0 && isnothing(x.size) ? 1. : x.size,
-                     get(m.compartments, compartment, nothing)), default)
+    let c = get(m.compartments, compartment, nothing)
+        mayfirst(
+            maylift(x -> x.size, c),
+            maylift(x -> x.spatial_dimensions == 0 ? 1.0 : nothing, c),
+            default,
+        )
+    end
 
 """
     initial_amounts(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -131,7 +131,7 @@ maylift(f, args::Maybe...) = any(isnothing, args) ? nothing : f(args...)
 A helper for easily getting out a defaulted compartment size.
 """
 get_compartment_size(m::SBML.Model, compartment; default = nothing) =
-    mayfirst(maylift(x -> x.spatial_dimensions == 0 ? 1. : x.size,
+    mayfirst(maylift(x -> x.spatial_dimensions == 0 && isnothing(x.size) ? 1. : x.size,
                      get(m.compartments, compartment, nothing)), default)
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -265,9 +265,11 @@ extensive_kinetic_math(m::SBML.Model, formula::SBML.Math) = interpret_math(
         sp = m.species[x.id]
         sp.only_substance_units && return x
         sz =
-            if !isboundbyrules(sp.compartment, m) &&
-               m.compartments[sp.compartment].spatial_dimensions == 0
-                # if the comparment ID isn't bound anywhere and it is a zero-dimensional compartment, default to 1.0
+            if isnothing(m.compartments[sp.compartment].size) &&
+               m.compartments[sp.compartment].spatial_dimensions == 0 &&
+               !isboundbyrules(sp.compartment, m)
+                # if the comparment ID isn't bound anywhere and it is a
+                # zero-dimensional unsized compartment, default to 1.0
                 SBML.MathVal(1.0)
             else
                 # otherwise just use the compartment ID as a variable

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -131,7 +131,8 @@ maylift(f, args::Maybe...) = any(isnothing, args) ? nothing : f(args...)
 A helper for easily getting out a defaulted compartment size.
 """
 get_compartment_size(m::SBML.Model, compartment; default = nothing) =
-    mayfirst(maylift(x -> x.size, get(m.compartments, compartment, nothing)), default)
+    mayfirst(maylift(x -> x.spatial_dimensions == 0 ? 1. : x.size,
+                     get(m.compartments, compartment, nothing)), default)
 
 """
     initial_amounts(
@@ -268,7 +269,7 @@ function extensive_kinetic_math(
         ),
     ),
 )
-            
+
     conv(x::SBML.MathIdent) = begin
         haskey(m.species, x.id) || return x
         sp = m.species[x.id]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -218,7 +218,7 @@ Determine if `id` is used and not bound (aka. free) in `expr`.
 """
 isfreein(id::String, expr::SBML.Math) = interpret_math(
     expr,
-    map_apply = any(rec.(x.body)),
+    map_apply = any(rec.(x.args)),
     map_const = _ -> false,
     map_ident = x -> x.id == id,
     map_lambda = (x, rec) -> id in x.args ? false : rec(x.body),
@@ -236,22 +236,18 @@ Determine if an identifier is defined or used by any Rules in the model.
 """
 isboundbyrules(id::String, m::SBML.Model) =
     any(r.id == id for r in m.rules if typeof(r) in [SBML.AssignmentRule, SBML.RateRule]) ||
-    any(isfreein(Ref(id), r.math for r in m.rules))
+    any(isfreein.(Ref(id), r.math for r in m.rules))
 
 """
     function extensive_kinetic_math(
         m::SBML.Model,
-        formula::SBML.Math;
-        handle_empty_compartment_size = (id::String) -> throw(
-            DomainError(
-                "Non-substance-only-unit reference to species `\$id' in an unsized compartment `\$(m.species[id].compartment)'",
-            ),
-        ),
+        formula::SBML.Math
     )
 
 Convert a SBML math `formula` to "extensive" kinetic laws, where the references
 to species that are marked as not having only substance units are converted
-from amounts to concentrations.
+from amounts to concentrations. Compartment sizes are referenced by compartment
+identifiers. A compartment with no spatial
 
 If the data is missing, you can supply a function that adds them. A common way
 to handle errors is to assume that unsized compartments have volume 1.0 (of
@@ -260,15 +256,7 @@ whatever units), you can specify that behavior by supplying
 
 Handling of units in the conversion process is ignored in this version.
 """
-extensive_kinetic_math(
-    m::SBML.Model,
-    formula::SBML.Math;
-    handle_empty_compartment_size = (id::String) -> throw(
-        DomainError(
-            "Non-substance-only-unit reference to species `$id' in an unsized compartment `$(m.species[id].compartment)'",
-        ),
-    ),
-) = interpret_math(
+extensive_kinetic_math(m::SBML.Model, formula::SBML.Math) = interpret_math(
     formula,
     map_apply = (x, rec) -> SBML.MathApply(x.fn, rec.(x.args)),
     map_const = identity,
@@ -276,12 +264,16 @@ extensive_kinetic_math(
         haskey(m.species, x.id) || return x
         sp = m.species[x.id]
         sp.only_substance_units && return x
-        sz = m.compartments[sp.compartment].size
-        isnothing(sz) &&
-            !isboundbyrules(sp.compartment, m) &&
-            (sz = handle_empty_compartment_size(x.id))
-        isnothing(sz) && c.spatial_dimensions == 0 && (sz = 1.0)
-        return SBML.MathApply("/", [x, SBML.MathIdent(sp.compartment)])
+        sz =
+            if !isboundbyrules(sp.compartment, m) &&
+               m.compartments[sp.compartment].spatial_dimensions == 0
+                # if the comparment ID isn't bound anywhere and it is a zero-dimensional compartment, default to 1.0
+                SBML.MathVal(1.0)
+            else
+                # otherwise just use the compartment ID as a variable
+                SBML.MathIdent(sp.compartment)
+            end
+        return SBML.MathApply("/", [x, sz])
     end,
     map_lambda = (x, _) -> error(
         ErrorException("converting lambdas to extensive kinetic math is not supported"),

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -36,6 +36,15 @@ sbmlfiles = [
         3,
         fill(Inf, 3),
     ),
+    # a cool model with assignmentRule for a compartment
+    (
+        joinpath(@__DIR__, "data", "sbml00140.xml"),
+        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00140/00140-sbml-l3v2.xml",
+        "43f0151c4f414b610b46bb62033fdcc177f4ac5cc39f3fe8b208e2e335c8d847",
+        3,
+        1,
+        fill(Inf, 1),
+    ),
     # another model from SBML suite, with initial concentrations
     (
         joinpath(@__DIR__, "data", "sbml00374.xml"),
@@ -286,7 +295,15 @@ end
         SBML.extensive_kinetic_math(m, m.reactions["reaction1"].kinetic_math).args[1].args[2]
     @test subterm.fn == "/"
     @test subterm.args[1] == SBML.MathIdent("S1")
-    @test isapprox(subterm.args[2].val, 1.0)
+    @test subterm.args[2] == SBML.MathIdent("C")
+    
+    m = readSBML(joinpath(@__DIR__, "data", "sbml00140.xml"))
+
+    subterm =
+        SBML.extensive_kinetic_math(m, m.reactions["reaction1"].kinetic_math).args[2]
+    @test subterm.fn == "/"
+    @test subterm.args[1] == SBML.MathIdent("S1")
+    @test subterm.args[2] == SBML.MathIdent("compartment")
 end
 
 @testset "logBase and root math functions" begin

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -296,11 +296,10 @@ end
     @test subterm.fn == "/"
     @test subterm.args[1] == SBML.MathIdent("S1")
     @test subterm.args[2] == SBML.MathIdent("C")
-    
+
     m = readSBML(joinpath(@__DIR__, "data", "sbml00140.xml"))
 
-    subterm =
-        SBML.extensive_kinetic_math(m, m.reactions["reaction1"].kinetic_math).args[2]
+    subterm = SBML.extensive_kinetic_math(m, m.reactions["reaction1"].kinetic_math).args[2]
     @test subterm.fn == "/"
     @test subterm.args[1] == SBML.MathIdent("S1")
     @test subterm.args[2] == SBML.MathIdent("compartment")

--- a/test/symbolics.jl
+++ b/test/symbolics.jl
@@ -11,11 +11,11 @@ end
 
 const interpret_as_num(x::SBML.Math) = SBML.interpret_math(
     x;
-    map_apply = (fn::String, args, interpret::Function) ->
-        Num(symbolics_mapping[fn](interpret.(args)...)),
+    map_apply = (x::SBML.MathApply, interpret::Function) ->
+        Num(symbolics_mapping[x.fn](interpret.(x.args)...)),
     map_const = (x::SBML.MathConst) -> Num(SBML.default_constants[x.id]),
     map_ident = map_symbolics_time_ident,
-    map_lambda = (x::SBML.MathLambda) ->
+    map_lambda = (_, _) ->
         throw(ErrorException("Symbolics.jl does not support lambda functions")),
     map_time = map_symbolics_time_ident,
     map_value = (x::SBML.MathVal) -> Num(x.val),


### PR DESCRIPTION
 (originally #194, but rebase failed there and I'm quickfixing it here)

cc @paulflang 