### PR TITLE
DocStringExtensions + some extra fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,7 @@
 name: Documentation
 
 on:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
-        with:
-          version: 1.5
       - name: Install dependencies
         run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-DocStringExtensions = "0.8"
+DocStringExtensions = "0.8, 0.9"
 IfElse = "0.1"
 Symbolics = "3, 4"
 Unitful = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,11 +11,12 @@ makedocs(
     authors = "The developers of SBML.jl",
     linkcheck = !("skiplinks" in ARGS),
     pages = ["Home" => "index.md", "Reference" => "functions.md"],
+    strict = [:missing_docs, :cross_references],
 )
 
 deploydocs(
     repo = "github.com/LCSB-BioCore/SBML.jl.git",
     target = "build",
     branch = "gh-pages",
-    push_preview = true,
+    push_preview = false,
 )

--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -24,6 +24,16 @@ Pages = ["SBML.jl"]
 
 ## Loading and versioning
 
+```@autodocs
+Modules = [SBML]
+Pages = ["readsbml.jl"]
+```
+
+```@autodocs
+Modules = [SBML]
+Pages = ["version.jl"]
+```
+
 ## `libsbml` representation converters
 
 The converters are intended to be used as parameters of [`readSBML`](@ref).
@@ -49,11 +59,11 @@ Modules = [SBML]
 Pages = ["unitful.jl"]
 ```
 
-## MathML representation and `Symbolics.jl` compatibility
+## Math interpretation
 
 ```@autodocs
 Modules = [SBML]
-Pages = ["symbolics.jl"]
+Pages = ["interpret.jl"]
 ```
 
 ### Internal math helpers

--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -21,6 +21,11 @@ include("readsbml.jl")
 include("unitful.jl")
 include("utils.jl")
 
+"""
+$(TYPEDSIGNATURES)
+
+A shortcut that loads a function symbol from `SBML_jll`.
+"""
 sbml(sym::Symbol)::VPtr = dlsym(SBML_jll.libsbml_handle, sym)
 
 export readSBML, readSBMLFromString, stoichiometry_matrix, flux_bounds, flux_objective

--- a/src/converters.jl
+++ b/src/converters.jl
@@ -1,6 +1,6 @@
 
 """
-    set_level_and_version(level, version, report_severities = ["Fatal", "Error"])
+$(TYPEDSIGNATURES)
 
 A converter to pass into [`readSBML`](@ref) that enforces certain SBML level
 and version.  `report_severities` switches on and off reporting of certain
@@ -22,7 +22,7 @@ set_level_and_version(level, version, report_severities = ["Fatal", "Error"]) =
     )
 
 """
-    libsbml_convert(conversion_options::Vector{Pair{String, Dict{String, String}}}, report_severities = ["Fatal", "Error"])
+$(TYPEDSIGNATURES)
 
 A converter that runs the SBML conversion routine, with specified conversion
 options. The argument is a vector of pairs to allow specifying the order of
@@ -61,7 +61,7 @@ libsbml_convert(
     end
 
 """
-    libsbml_convert(converter::String, report_severities = ["Fatal", "Error"]; kwargs...)
+$(TYPEDSIGNATURES)
 
 Quickly construct a single run of a `libsbml` converter from keyword arguments.
 `report_severities` switches on and off reporting of certain errors; see the
@@ -79,7 +79,7 @@ libsbml_convert(converter::String, report_severities = ["Fatal", "Error"]; kwarg
     )
 
 """
-    convert_simplify_math
+$(TYPEDSIGNATURES)
 
 Shortcut for [`libsbml_convert`](@ref) that expands functions, local
 parameters, and initial assignments in the SBML document.

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -22,7 +22,7 @@ sbmlRoot(power, x) = x^(1 / power)
 sbmlRateOf(x) = throw(ErrorException("`rateOf' function mapping not defined"))
 
 """
-    default_function_mapping :: Dict{String,Any}
+$(TYPEDSIGNATURES)
 
 Default mapping of SBML function names to Julia functions, represented as a
 dictionary from Strings (SBML names) to functions.
@@ -88,7 +88,7 @@ allowed_sym(x, allowed_funs) =
     throw(DomainError(x, "Unknown SBML function"))
 
 """
-    const default_constants::Dict{String, Any}
+$(TYPEDSIGNATURES)
 
 A dictionary of default constants filled in place of SBML Math constants in the
 function conversion.
@@ -97,15 +97,7 @@ const default_constants =
     Dict{String,Any}("true" => true, "false" => false, "pi" => pi, "e" => exp(1))
 
 """
-    function interpret_math(
-        x::SBML.Math;
-        map_apply = (fn::String, args, interpret::Function) -> SBML.default_function_mapping[fn](interpret.(args)...),
-        map_const = (x::SBML.MathConst) -> default_constants[x.id],
-        map_ident = (x::SBML.MathIdent) -> throw(ErrorException("identifier mapping not defined")),
-        map_lambda = (x::SBML.MathLambda) -> throw(ErrorException("lambda function mapping not defined")),
-        map_time = (x::SBML.MathTime) -> throw(ErrorException("time mapping not defined")),
-        map_value = (x::SBML.MathVal) -> x.val,
-    )
+$(TYPEDSIGNATURES)
 
 Recursively interpret SBML.[`Math`](@ref) type. This can be used to relatively
 easily traverse and evaluate the SBML math, or translate it into any custom

--- a/src/math.jl
+++ b/src/math.jl
@@ -1,13 +1,13 @@
 
 """
-    ast_is(ast::VPtr, what::Symbol)::Bool
+$(TYPEDSIGNATURES)
 
 Helper for quickly recognizing kinds of ASTs
 """
 ast_is(ast::VPtr, what::Symbol)::Bool = ccall(sbml(what), Cint, (VPtr,), ast) != 0
 
 """
-    parse_math_children(ast::VPtr)::Vector{Math}
+$(TYPEDSIGNATURES)
 
 Recursively parse all children of an AST node.
 """
@@ -36,9 +36,9 @@ function relational_oper(t::Int)
 end
 
 """
-    parse_math(ast::VPtr)::Math
+$(TYPEDSIGNATURES)
 
-This attempts to parse out a decent Julia-esque ([`Math`](@ref) AST from a
+This attempts to parse out a decent Julia-esque [`Math`](@ref) AST from a
 pointer to `ASTNode_t`.
 """
 function parse_math(ast::VPtr)::Math

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -214,7 +214,7 @@ get_parameter(p::VPtr)::Pair{String,Parameter} =
         constant = get_optional_bool(p, :Parameter_isSetConstant, :Parameter_getConstant),
     )
 
-""""
+"""
 $(TYPEDSIGNATURES)
 
 Take the `SBMLModel_t` pointer and extract all information required to make a

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -1,5 +1,5 @@
 """
-    get_string(x::VPtr, fn_sym)::Maybe{String}
+$(TYPEDSIGNATURES)
 
 C-call the SBML function `fn_sym` with a single parameter `x`, interpret the
 result as a string and return it, or throw exception in case the pointer is
@@ -15,7 +15,7 @@ function get_string(x::VPtr, fn_sym)::String
 end
 
 """
-    get_optional_string(x::VPtr, fn_sym)::Maybe{String}
+$(TYPEDSIGNATURES)
 
 Like [`get_string`](@ref), but returns `nothing` instead of throwing an
 exception.
@@ -33,7 +33,7 @@ function get_optional_string(x::VPtr, fn_sym)::Maybe{String}
 end
 
 """
-    get_optional_bool(x::VPtr, is_sym, get_sym)::Maybe{Bool}
+$(TYPEDSIGNATURES)
 
 Helper for getting out boolean flags.
 """
@@ -46,7 +46,7 @@ function get_optional_bool(x::VPtr, is_sym, get_sym)::Maybe{Bool}
 end
 
 """
-    get_optional_int(x::VPtr, is_sym, get_sym)::Maybe{UInt}
+$(TYPEDSIGNATURES)
 
 Helper for getting out unsigned integers.
 """
@@ -59,7 +59,7 @@ function get_optional_int(x::VPtr, is_sym, get_sym)::Maybe{Int}
 end
 
 """
-    get_optional_double(x::VPtr, is_sym, get_sym)::Maybe{Float64}
+$(TYPEDSIGNATURES)
 
 Helper for getting out C doubles aka Float64s.
 """
@@ -88,6 +88,11 @@ function get_string_from_xmlnode(xmlnode::VPtr)::String
     end
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Internal helper for [`readSBML`](@ref).
+"""
 function _readSBML(
     symbol::Symbol,
     fn::String,
@@ -117,11 +122,7 @@ function _readSBML(
 end
 
 """
-    readSBML(
-        fn::String,
-        sbml_conversion = document -> nothing;
-        report_severities = ["Fatal", "Error"],
-    )::SBML.Model
+$(TYPEDSIGNATURES)
 
 Read the SBML from a XML file in `fn` and return the contained `SBML.Model`.
 
@@ -152,12 +153,9 @@ function readSBML(
     isfile(fn) || throw(AssertionError("$(fn) is not a file"))
     _readSBML(:readSBML, fn, sbml_conversion, report_severities)
 end
+
 """
-    readSBML(
-        str::String,
-        sbml_conversion = document -> nothing;
-        report_severities = ["Fatal", "Error"],
-    )::SBML.Model
+$(TYPEDSIGNATURES)
 
 Read the SBML from the string `str` and return the contained `SBML.Model`.
 
@@ -175,7 +173,7 @@ get_notes(x::VPtr)::Maybe{String} = get_optional_string(x, :SBase_getNotesString
 get_annotation(x::VPtr)::Maybe{String} = get_optional_string(x, :SBase_getAnnotationString)
 
 """
-    function get_association(x::VPtr)::GeneProductAssociation
+$(TYPEDSIGNATURES)
 
 Convert a pointer to SBML `FbcAssociation_t` to the `GeneProductAssociation`
 tree structure.
@@ -203,6 +201,11 @@ function get_association(x::VPtr)::GeneProductAssociation
     end
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Extract the value of SBML `Parameter_t`.
+"""
 get_parameter(p::VPtr)::Pair{String,Parameter} =
     get_string(p, :Parameter_getId) => Parameter(
         name = get_optional_string(p, :Parameter_getName),
@@ -212,7 +215,7 @@ get_parameter(p::VPtr)::Pair{String,Parameter} =
     )
 
 """"
-    function get_model(mdl::VPtr)::SBML.Model
+$(TYPEDSIGNATURES)
 
 Take the `SBMLModel_t` pointer and extract all information required to make a
 valid [`SBML.Model`](@ref) structure.

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -1,5 +1,7 @@
 
 """
+$(TYPEDEF)
+
 Part of a measurement unit definition that corresponds to the SBML definition
 of `Unit`. For example, the unit "per square megahour", Mh^(-2), is written as:
 
@@ -10,6 +12,9 @@ of `Unit`. For example, the unit "per square megahour", Mh^(-2), is written as:
 
 Compound units (such as "volt-amperes" and "dozens of yards per ounce") are
 built from multiple `UnitPart`s.  See also [`SBML.UnitDefinition`](@ref).
+
+# Fields
+$(TYPEDFIELDS)
 """
 Base.@kwdef struct UnitPart
     kind::String
@@ -35,26 +40,46 @@ end
 
 
 """
+$(TYPEDEF)
+
 Abstract type for all kinds of gene product associations
+
+# Fields
+$(TYPEDFIELDS)
 """
 abstract type GeneProductAssociation end
 
 """
+$(TYPEDEF)
+
 Gene product reference in the association expression
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct GPARef <: GeneProductAssociation
     gene_product::String
 end
 
 """
+$(TYPEDEF)
+
 Boolean binary "and" in the association expression
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct GPAAnd <: GeneProductAssociation
     terms::Vector{GeneProductAssociation}
 end
 
 """
+$(TYPEDEF)
+
 Boolean binary "or" in the association expression
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct GPAOr <: GeneProductAssociation
     terms::Vector{GeneProductAssociation}
@@ -66,37 +91,62 @@ A simplified representation of MathML-specified math AST
 abstract type Math end
 
 """
+$(TYPEDEF)
+
 A literal value (usually a numeric constant) in mathematical expression
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct MathVal{T} <: Math where {T}
     val::T
 end
 
 """
+$(TYPEDEF)
+
 An identifier (usually a variable name) in mathematical expression
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct MathIdent <: Math
     id::String
 end
 
 """
+$(TYPEDEF)
+
 A constant identified by name (usually something like `pi`, `e` or `true`) in
 mathematical expression
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct MathConst <: Math
     id::String
 end
 
 """
+$(TYPEDEF)
+
 A special value representing the current time of the simulation, with a special
 name.
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct MathTime <: Math
     id::String
 end
 
 """
+$(TYPEDEF)
+
 Function application ("call by name", no tricks allowed) in mathematical expression
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct MathApply <: Math
     fn::String
@@ -104,7 +154,12 @@ struct MathApply <: Math
 end
 
 """
+$(TYPEDEF)
+
 Function definition (aka "lambda") in mathematical expression
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct MathLambda <: Math
     args::Vector{String}
@@ -268,7 +323,12 @@ Base.@kwdef struct GeneProduct
 end
 
 """
+$(TYPEDEF)
+
 Custom function definition.
+
+# Fields
+$(TYPEDFIELDS)
 """
 Base.@kwdef struct FunctionDefinition
     name::Maybe{String} = nothing

--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -44,7 +44,7 @@ const UNITFUL_KIND_STRING = Dict(
 
 
 """
-    unitful(units::UnitDefinition)
+$(TYPEDSIGNATURES)
 
 Converts an SBML unit definition (i.e., its vector of [`UnitPart`](@ref)s) to a
 corresponding Unitful unit.
@@ -52,7 +52,7 @@ corresponding Unitful unit.
 unitful(u::UnitDefinition) = unitful(u.unit_parts)
 
 """
-    unitful(u::UnitPart)
+$(TYPEDSIGNATURES)
 
 Converts a [`UnitPart`](@ref) to a corresponding Unitful unit.
 
@@ -63,7 +63,7 @@ unitful(u::UnitPart) =
     (u.multiplier * UNITFUL_KIND_STRING[u.kind] * exp10(u.scale))^u.exponent
 
 """
-    unitful(units::Vector{UnitPart})
+$(TYPEDSIGNATURES)
 
 Converts an SBML unit (i.e., a vector of [`UnitPart`](@ref)s) to a corresponding
 Unitful unit.
@@ -71,7 +71,7 @@ Unitful unit.
 unitful(u::Vector{UnitPart}) = prod(unitful.(u))
 
 """
-    unitful(m::Model, val::Tuple{Float64,String})
+$(TYPEDSIGNATURES)
 
 Computes a properly unitful value from a value-unit pair stored in the model
 `m`.
@@ -79,7 +79,7 @@ Computes a properly unitful value from a value-unit pair stored in the model
 unitful(m::Model, val::Tuple{Float64,String}) = unitful(m.units[val[2]]) * val[1]
 
 """
-    unitful(m::Model, val::Tuple{Float64, String}, default_unit::Number)
+$(TYPEDSIGNATURES)
 
 Overload of [`unitful`](@ref) that uses the `default_unit` if the unit is not
 found in the model.
@@ -94,7 +94,7 @@ unitful(m::Model, val::Tuple{Float64,String}, default_unit::Number) =
     mayfirst(maylift(unitful, get(m.units, val[2], nothing)), default_unit) * val[1]
 
 """
-    unitful(m::Model, val::Tuple{Float64, String}, default_unit::String)
+$(TYPEDSIGNATURES)
 
 Overload of [`unitful`](@ref) that allows specification of the `default_unit` by
 string ID.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 """
-    function stoichiometry_matrix(m::SBML.Model)
+$(TYPEDSIGNATURES)
 
 Extract the vector of species (aka metabolite) identifiers, vector of reaction
 identifiers, and a sparse stoichiometry matrix (of type `SparseMatrixCSC` from
@@ -46,7 +46,7 @@ function stoichiometry_matrix(m::SBML.Model)
 end
 
 """
-    flux_bounds(m::SBML.Model)::NTuple{2, Vector{Tuple{Float64,String}}}
+$(TYPEDSIGNATURES)
 
 Extract the vectors of lower and upper bounds of reaction rates from the model,
 in the same order as `keys(m.reactions)`.  All bounds are accompanied with the
@@ -87,7 +87,7 @@ function flux_bounds(m::SBML.Model)::NTuple{2,Vector{Tuple{Float64,String}}}
 end
 
 """
-    flux_objective(m::SBML.Model)::Vector{Float64}
+$(TYPEDSIGNATURES)
 
 Extract the vector of objective coefficients of each reaction, in the same
 order as `keys(m.reactions)`.
@@ -104,7 +104,7 @@ function flux_objective(m::SBML.Model)::Vector{Float64}
 end
 
 """
-    mayfirst(args::Maybe{T}...)::Maybe{T} where T
+$(TYPEDSIGNATURES)
 
 Helper to get the first non-`nothing` value from the arguments.
 """
@@ -118,7 +118,7 @@ function mayfirst(args...)
 end
 
 """
-    maylift(f, args::Maybe...)
+$(TYPEDSIGNATURES)
 
 Helper to lift a function to work on [`Maybe`](@ref), returning `nothing`
 whenever there's a `nothing` in args.
@@ -126,7 +126,7 @@ whenever there's a `nothing` in args.
 maylift(f, args::Maybe...) = any(isnothing, args) ? nothing : f(args...)
 
 """
-    get_compartment_size(m::SBML.Model, compartment; default = nothing)
+$(TYPEDSIGNATURES)
 
 A helper for easily getting out a defaulted compartment size.
 """
@@ -140,11 +140,7 @@ get_compartment_size(m::SBML.Model, compartment; default = nothing) =
     end
 
 """
-    initial_amounts(
-        m::SBML.Model;
-        convert_concentrations = false,
-        compartment_size = comp -> get_compartment_size(m, comp),
-    )
+$(TYPEDSIGNATURES)
 
 Return initial amounts for each species as a generator of pairs
 `species_name => initial_amount`; the amount is set to `nothing` if not
@@ -189,11 +185,7 @@ initial_amounts(
 )
 
 """
-    initial_concentrations(
-        m::SBML.Model;
-        convert_amounts = false,
-        compartment_size = comp -> get_compartment_size(m, comp),
-    )
+$(TYPEDSIGNATURES)
 
 Return initial concentrations of the species in the model. Refer to work-alike
 [`initial_amounts`](@ref) for details.
@@ -240,10 +232,7 @@ seemsdefined(id::String, m::SBML.Model) =
     any(isfreein(id, r.math) for r in m.rules if r isa AlgebraicRule)
 
 """
-    function extensive_kinetic_math(
-        m::SBML.Model,
-        formula::SBML.Math
-    )
+$(TYPEDSIGNATURES)
 
 Convert a SBML math `formula` to "extensive" kinetic laws, where the references
 to species that are marked as not having only substance units are converted
@@ -294,7 +283,7 @@ extensive_kinetic_math(m::SBML.Model, formula::SBML.Math) = interpret_math(
 )
 
 """
-    get_error_messages(doc::VPtr, error::Exception, report_severities)
+$(TYPEDSIGNATURES)
 
 Show the error messages reported by SBML in the `doc` document and throw the
 `error` if they are more than 1.
@@ -327,12 +316,7 @@ function get_error_messages(doc::VPtr, error::Exception, report_severities)
 end
 
 """
-    check_errors(
-        success::Integer,
-        doc::VPtr,
-        error::Exception,
-        report_severities = ["Fatal", "Error"],
-    )
+$(TYPEDSIGNATURES)
 
 If success is a 0-valued `Integer` (a logical `false`), then call
 [`get_error_messages`](@ref) to show the error messages reported by SBML in the
@@ -347,6 +331,12 @@ check_errors(
     report_severities = ["Fatal", "Error"],
 ) = Bool(success) || get_error_messages(doc, error, report_severities)
 
+"""
+$(TYPEDSIGNATURES)
+
+Pretty-printer for a SBML model.
+Avoids flushing too much stuff to terminal by accident.
+"""
 function Base.show(io::IO, ::MIME"text/plain", m::SBML.Model)
     print(
         io,

--- a/src/version.jl
+++ b/src/version.jl
@@ -1,6 +1,6 @@
 
 """
-    function SBML.Version()
+$(TYPEDSIGNATURES)
 
 Get the version of the used SBML library in Julia version format.
 """


### PR DESCRIPTION
- `interpret_math` fix backported from #199 
- convert everything to DSE 0.9 because that can wrap long function definitions! (see https://github.com/JuliaDocs/DocStringExtensions.jl/pull/128# )