### PR TITLE
further formatter improvements

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -7,7 +7,7 @@ name: Formatting
 
 jobs:
   formatting:
-    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.issue.user.id == github.event.comment.user.id) && startsWith(github.event.comment.body, '/format')
+    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.issue.user.id == github.event.comment.user.id) && startsWith(github.event.comment.body, '/format') )
     runs-on: ubuntu-latest
     steps:
       - name: Clone the repository

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -7,7 +7,7 @@ name: Formatting
 
 jobs:
   formatting:
-    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.issue.user.id == github.event.comment.user.id) && startsWith(github.event.comment.body, '/format')
     runs-on: ubuntu-latest
     steps:
       - name: Clone the repository
@@ -48,7 +48,7 @@ jobs:
           ":green_circle: &nbsp;Commit ${{ github.event.pull_request.head.sha }} is formatted properly."
           fi
       - name: Commit fixes
-        if: github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.issue.user.id == github.event.comment.user.id) && startsWith(github.event.comment.body, '/format')
+        if: github.event_name == 'issue_comment'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -7,6 +7,7 @@ name: Formatting
 
 jobs:
   formatting:
+    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
     runs-on: ubuntu-latest
     steps:
       - name: Clone the repository

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Clone the repository
         uses: actions/checkout@v3
-      - name: Checkout the pull request code
+      - name: Checkout the pull request code # this checks out the actual branch so that one can commit into it
         if: github.event_name == 'issue_comment'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,17 +35,26 @@ jobs:
             sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' "$filename"
           done
       - name: Report problems
-        if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'pull_request' && env.GITHUB_TOKEN != ''
         run: |
-          if [ `git status -s | wc -l` -ne 0 ]
+          if git diff --exit-code --quiet
           then gh pr comment ${{ github.event.number }} --body \
+          ":green_circle: &nbsp;Commit ${{ github.event.pull_request.head.sha }} is formatted properly."
+          else gh pr comment ${{ github.event.number }} --body \
           ":red_square: &nbsp;Commit ${{ github.event.pull_request.head.sha }} requires formatting!\
           "$'\n\n'"Required formatting changes summary:\
           "$'\n```\n'"`git diff --stat`"$'\n```'
-          else gh pr comment ${{ github.event.number }} --body \
-          ":green_circle: &nbsp;Commit ${{ github.event.pull_request.head.sha }} is formatted properly."
+          fi
+      - name: Fail on formatting problems
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'pull_request' && env.GITHUB_TOKEN == '' # pull from another repository cannot comment because there's no token
+        run: |
+          if git diff --exit-code --quiet
+          then echo "Looks OK"
+          else echo "Formatting fixes required!"; git diff -p ; exit 1
           fi
       - name: Commit fixes
         if: github.event_name == 'issue_comment'


### PR DESCRIPTION
Github actions battle continues!

this 
- prevents ordinary issue comments from triggering the action (the `if` is global for the whole job)
- detect if github_token secret is available and attempts to fail gracefully if not (producing a CI fail instead of friendly warning comment)