### PR TITLE
fix isfreein()

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -210,7 +210,7 @@ Determine if `id` is used and not bound (aka. free) in `expr`.
 """
 isfreein(id::String, expr::SBML.Math) = interpret_math(
     expr,
-    map_apply = any(rec.(x.args)),
+    map_apply = (x, rec) -> any(rec.(x.args)),
     map_const = _ -> false,
     map_ident = x -> x.id == id,
     map_lambda = (x, rec) -> id in x.args ? false : rec(x.body),


### PR DESCRIPTION
I think this still needs a test case, but Idk where to put it best. For me, this failed with test suite case 39, which uses an algebraicRule with math `SBML.MathApply("+", SBML.Math[SBML.MathApply("+", SBML.Math[SBML.MathApply("*", SBML.Math[SBML.MathVal{Int32}(-1), SBML.MathIdent("k1")]), SBML.MathIdent("S1")]), SBML.MathIdent("S2")])`.