### PR TITLE
Test starting from Julia v1.6 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5' # Oldest supported version of SBML.jl
+          - '1.6' # Oldest supported version of SBML.jl
           - '1' # This is always the latest stable release in the 1.X series
           - 'nightly'
         os:


### PR DESCRIPTION
`SBML.jl` already requires Julia v1.6: https://github.com/LCSB-BioCore/SBML.jl/blob/6a124f994be04f33f2398f00b8676e1c258c3546/Project.toml#L19 but we're currently testing Julia v1.5.