### PR TITLE
simplify format check reporting

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -34,23 +34,8 @@ jobs:
             # squash superfluous final newlines
             sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' "$filename"
           done
-      - name: Report problems
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'pull_request' && env.GITHUB_TOKEN != ''
-        run: |
-          if git diff --exit-code --quiet
-          then gh pr comment ${{ github.event.number }} --body \
-          ":green_circle: &nbsp;Commit ${{ github.event.pull_request.head.sha }} is formatted properly."
-          else gh pr comment ${{ github.event.number }} --body \
-          ":red_square: &nbsp;Commit ${{ github.event.pull_request.head.sha }} requires formatting!\
-          "$'\n\n'"Required formatting changes summary:\
-          "$'\n```\n'"`git diff --stat`"$'\n```'
-          fi
       - name: Fail on formatting problems
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'pull_request' && env.GITHUB_TOKEN == '' # pull from another repository cannot comment because there's no token
+        if: github.event_name == 'pull_request'
         run: |
           if git diff --exit-code --quiet
           then echo "Looks OK"

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -52,10 +52,11 @@ jobs:
             git commit -a -m "automatic formatting" -m "triggered by @$GITHUB_ACTOR on PR #${{ github.event.issue.number }}"
             if git push
             then gh pr comment ${{ github.event.issue.number }} --body \
-              ":heavy_check_mark: auto-formatting triggered by [this comment](${{ github.event.comment.html_url }}) succeeded, commited as `git rev-parse HEAD`"
+              ":heavy_check_mark: Auto-formatting triggered by [this comment](${{ github.event.comment.html_url }}) succeeded, commited as `git rev-parse HEAD`"
             else gh pr comment ${{ github.event.issue.number }} --body \
-              ":x: auto-formatting triggered by [this comment](${{ github.event.comment.html_url }}) failed, perhaps someone pushed to the PR in the meantime?"
+              ":x: Auto-formatting triggered by [this comment](${{ github.event.comment.html_url }}) failed, perhaps someone pushed to the PR in the meantime?"
             fi
           else
-            echo "No changes, all good!"
+            then gh pr comment ${{ github.event.issue.number }} --body \
+              ":sunny: Auto-formatting triggered by [this comment](${{ github.event.comment.html_url }}) succeeded, but the code was already formatted correctly."
           fi


### PR DESCRIPTION
Since it looks like you can't easily make a gh action depend on secret presence, let's just fail if the formatting is bad.