### PR TITLE
implement full species references

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBML"
 uuid = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
 authors = ["Mirek Kratochvil <miroslav.kratochvil@uni.lu>", "LCSB R3 team <lcsb-r3@uni.lu>"]
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -429,6 +429,11 @@ function get_model(mdl::VPtr)::SBML.Model
             push!(
                 coll,
                 SpeciesReference(
+                    id = get_optional_string(
+                        sr,
+                        :SpeciesReference_isSetId,
+                        :SpeciesReference_getId,
+                    ),
                     species = get_string(sr, :SpeciesReference_getSpecies);
                     stoichiometry,
                     constant,

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -199,6 +199,20 @@ end
 """
 $(TYPEDEF)
 
+SBML SpeciesReference.
+
+# Fields
+$(TYPEDFIELDS)
+"""
+Base.@kwdef struct SpeciesReference
+    species::String
+    stoichiometry::Maybe{Float64} = nothing
+    constant::Maybe{Bool} = nothing
+end
+
+"""
+$(TYPEDEF)
+
 Reaction with stoichiometry that assigns reactants and products their relative
 consumption/production rates, lower/upper bounds (in tuples `lb` and `ub`, with
 unit names), and objective coefficient (`oc`). Also may contains `notes` and
@@ -209,8 +223,8 @@ $(TYPEDFIELDS)
 """
 Base.@kwdef struct Reaction
     name::Maybe{String} = nothing
-    reactants::Dict{String,Float64} = Dict()
-    products::Dict{String,Float64} = Dict()
+    reactants::Vector{SpeciesReference} = []
+    products::Vector{SpeciesReference} = []
     kinetic_parameters::Dict{String,Parameter} = Dict()
     lower_bound::Maybe{String} = nothing
     upper_bound::Maybe{String} = nothing

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -205,6 +205,7 @@ SBML SpeciesReference.
 $(TYPEDFIELDS)
 """
 Base.@kwdef struct SpeciesReference
+    id::Maybe{String} = nothing
     species::String
     stoichiometry::Maybe{Float64} = nothing
     constant::Maybe{Bool} = nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -64,15 +64,15 @@ function stoichiometry_matrix(m::SBML.Model)
 
     for (rid, r) in m.reactions
         ridx = col_idx[rid]
-        for (sid, stoi) in r.reactants
-            push!(SI, row_idx[sid])
+        for sr in r.reactants
+            push!(SI, row_idx[sr.species])
             push!(RI, ridx)
-            push!(SV, -stoi)
+            push!(SV, -sr.stoichiometry)
         end
-        for (sid, stoi) in r.products
-            push!(SI, row_idx[sid])
+        for sr in r.products
+            push!(SI, row_idx[sr.species])
             push!(RI, ridx)
-            push!(SV, stoi)
+            push!(SV, sr.stoichiometry)
         end
     end
     return rows, cols, SparseArrays.sparse(SI, RI, SV, length(rows), length(cols))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -67,12 +67,12 @@ function stoichiometry_matrix(m::SBML.Model)
         for sr in r.reactants
             push!(SI, row_idx[sr.species])
             push!(RI, ridx)
-            push!(SV, -sr.stoichiometry)
+            push!(SV, isnothing(sr.stoichiometry) ? -1.0 : -sr.stoichiometry)
         end
         for sr in r.products
             push!(SI, row_idx[sr.species])
             push!(RI, ridx)
-            push!(SV, sr.stoichiometry)
+            push!(SV, isnothing(sr.stoichiometry) ? 1.0 : sr.stoichiometry)
         end
     end
     return rows, cols, SparseArrays.sparse(SI, RI, SV, length(rows), length(cols))

--- a/src/writesbml.jl
+++ b/src/writesbml.jl
@@ -403,6 +403,13 @@ function model_to_sbml!(doc::VPtr, mdl::Model)::VPtr
                     reactant_ptr,
                     sr.species,
                 )
+                isnothing(sr.id) || ccall(
+                    sbml(:SpeciesReference_setId),
+                    Cint,
+                    (VPtr, Cstring),
+                    reactant_ptr,
+                    sr.id,
+                )
                 isnothing(sr.stoichiometry) || ccall(
                     sbml(:SpeciesReference_setStoichiometry),
                     Cint,


### PR DESCRIPTION
Closes #218 .

There's a bit of re-juggling of the test file contents because our fav L2 models don't have the SpeciesReferences attributes that are required for L3.