### PR TITLE
`use_value_from_trigger_time` is semantically a Bool

### DIFF
--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -659,7 +659,7 @@ function get_model(mdl::VPtr)::SBML.Model
                     Cint,
                     (VPtr,),
                     ev,
-                ),
+                ) != 0,
                 name = get_optional_string(ev, :Event_getName),
                 trigger,
                 event_assignments,

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -435,7 +435,7 @@ $(TYPEDEF)
 $(TYPEDFIELDS)
 """
 Base.@kwdef struct Event
-    use_values_from_trigger_time::Cint
+    use_values_from_trigger_time::Bool
     name::Maybe{String} = nothing
     trigger::Maybe{Trigger} = nothing
     event_assignments::Maybe{Vector{EventAssignment}} = nothing

--- a/src/writesbml.jl
+++ b/src/writesbml.jl
@@ -452,7 +452,7 @@ function model_to_sbml!(doc::VPtr, mdl::Model)::VPtr
     for (id, event) in mdl.events
         event_ptr = ccall(sbml(:Model_createEvent), VPtr, (VPtr,), model)
         set_string!(event_ptr, :Event_setId, id)
-        set_int!(
+        set_bool!(
             event_ptr,
             :Event_setUseValuesFromTriggerTime,
             event.use_values_from_trigger_time,


### PR DESCRIPTION
might be breaking, but technically it only breaks broken code.... :D