### PR TITLE
add convert_promote_expand

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBML"
 uuid = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
 authors = ["Mirek Kratochvil <miroslav.kratochvil@uni.lu>", "LCSB R3 team <lcsb-r3@uni.lu>"]
-version = "1.2.0"
+version = "1.4.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -31,7 +31,7 @@ sbml(sym::Symbol)::VPtr = dlsym(SBML_jll.libsbml_handle, sym)
 
 export readSBML, readSBMLFromString, stoichiometry_matrix, flux_bounds, flux_objective
 export writeSBML
-export set_level_and_version, libsbml_convert, convert_simplify_math
+export set_level_and_version, libsbml_convert, convert_simplify_math, convert_promote_expand
 
 # Read a file at precompile time, to improve time-to-first `readSBML`.
 writeSBML(readSBML(joinpath(@__DIR__, "..", "test", "data", "Dasgupta2020-written.xml")))

--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -31,7 +31,7 @@ sbml(sym::Symbol)::VPtr = dlsym(SBML_jll.libsbml_handle, sym)
 
 export readSBML, readSBMLFromString, stoichiometry_matrix, flux_bounds, flux_objective
 export writeSBML
-export set_level_and_version, libsbml_convert, convert_simplify_math, convert_promote_expand
+export set_level_and_version, libsbml_convert, convert_simplify_math, convert_promotelocals_expandfuns
 
 # Read a file at precompile time, to improve time-to-first `readSBML`.
 writeSBML(readSBML(joinpath(@__DIR__, "..", "test", "data", "Dasgupta2020-written.xml")))

--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -31,7 +31,8 @@ sbml(sym::Symbol)::VPtr = dlsym(SBML_jll.libsbml_handle, sym)
 
 export readSBML, readSBMLFromString, stoichiometry_matrix, flux_bounds, flux_objective
 export writeSBML
-export set_level_and_version, libsbml_convert, convert_simplify_math, convert_promotelocals_expandfuns
+export set_level_and_version,
+    libsbml_convert, convert_simplify_math, convert_promotelocals_expandfuns
 
 # Read a file at precompile time, to improve time-to-first `readSBML`.
 writeSBML(readSBML(joinpath(@__DIR__, "..", "test", "data", "Dasgupta2020-written.xml")))

--- a/src/converters.jl
+++ b/src/converters.jl
@@ -95,5 +95,6 @@ Shortcut for [`libsbml_convert`](@ref) that expands functions and local
 parameters in the SBML document.
 """
 const convert_promote_expand = libsbml_convert(
-    ["promoteLocalParameters", "expandFunctionDefinitions"] .=> Ref(Dict{String,String}()),
+    ["promoteLocalParameters", "expandFunctionDefinitions"] .=>
+        Ref(Dict{String,String}()),
 )

--- a/src/converters.jl
+++ b/src/converters.jl
@@ -94,7 +94,7 @@ $(TYPEDSIGNATURES)
 Shortcut for [`libsbml_convert`](@ref) that expands functions and local
 parameters in the SBML document.
 """
-const convert_promote_expand = libsbml_convert(
+const convert_promotelocals_expandfuns = libsbml_convert(
     ["promoteLocalParameters", "expandFunctionDefinitions"] .=>
         Ref(Dict{String,String}()),
 )

--- a/src/converters.jl
+++ b/src/converters.jl
@@ -87,3 +87,13 @@ parameters, and initial assignments in the SBML document.
 const convert_simplify_math = libsbml_convert(
     ["promoteLocalParameters", "expandFunctionDefinitions", "expandInitialAssignments"] .=> Ref(Dict{String,String}()),
 )
+
+"""
+$(TYPEDSIGNATURES)
+
+Shortcut for [`libsbml_convert`](@ref) that expands functions and local
+parameters in the SBML document.
+"""
+const convert_promote_expand = libsbml_convert(
+    ["promoteLocalParameters", "expandFunctionDefinitions"] .=> Ref(Dict{String,String}()),
+)

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -156,7 +156,7 @@ The `sbml_conversion` is a function that does an in-place modification of the
 single parameter, which is the C pointer to the loaded SBML document (C type
 `SBMLDocument*`). Several functions for doing that are prepared, including
 [`set_level_and_version`](@ref), [`libsbml_convert`](@ref),
-[`convert_simplify_math`](@ref) and [`convert_promote_expand`](@ref).
+[`convert_simplify_math`](@ref) and [`convert_promotelocals_expandfuns`](@ref).
 
 `report_severities` switches on and off reporting of certain errors; see the
 documentation of [`get_error_messages`](@ref) for details.

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -155,8 +155,8 @@ Read the SBML from a XML file in `fn` and return the contained `SBML.Model`.
 The `sbml_conversion` is a function that does an in-place modification of the
 single parameter, which is the C pointer to the loaded SBML document (C type
 `SBMLDocument*`). Several functions for doing that are prepared, including
-[`set_level_and_version`](@ref), [`libsbml_convert`](@ref), and
-[`convert_simplify_math`](@ref).
+[`set_level_and_version`](@ref), [`libsbml_convert`](@ref),
+[`convert_simplify_math`](@ref) and [`convert_promote_expand`](@ref).
 
 `report_severities` switches on and off reporting of certain errors; see the
 documentation of [`get_error_messages`](@ref) for details.

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -343,7 +343,7 @@ end
         joinpath(@__DIR__, "data", "sbml00878.xml"),
         doc -> begin
             set_level_and_version(3, 1)(doc)
-            convert_promote_expand(doc)
+            convert_promotelocals_expandfuns(doc)
         end,
     ).initial_assignments["S2"]
 

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -339,6 +339,20 @@ end
         end,
     )
 
+    test_math = readSBML(
+        joinpath(@__DIR__, "data", "sbml00878.xml"),
+        doc -> begin
+            set_level_and_version(3, 1)(doc)
+            convert_promote_expand(doc)
+        end,
+        ).initial_assignments["S2"]
+            
+    @test test_math.fn == "*"
+    @test test_math.args[1].fn == "*"
+    @test test_math.args[1].args[1].id == "p1"
+    @test test_math.args[1].args[2].id == "S1"
+    @test test_math.args[2].id == "time"
+
     test_math =
         readSBML(
             joinpath(@__DIR__, "data", "sbml01565.xml"),

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -143,6 +143,15 @@ sbmlfiles = [
         0,
         [],
     ),
+    # contains initialAssignment
+    (
+        joinpath(@__DIR__, "data", "00878-sbml-l3v2.xml"),
+        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/release/cases/semantic/00878/00878-sbml-l3v2.xml",
+        "5f70555d27469a2fdc63dedcd8d02d50b6f4f1c760802cbb5e7bb17363c2e931",
+        2,
+        1,
+        fill(Inf, 1),
+    ),
 ]
 
 @testset "Loading of models from various sources - $(reader)" for reader in (

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -345,8 +345,8 @@ end
             set_level_and_version(3, 1)(doc)
             convert_promote_expand(doc)
         end,
-        ).initial_assignments["S2"]
-            
+    ).initial_assignments["S2"]
+
     @test test_math.fn == "*"
     @test test_math.args[1].fn == "*"
     @test test_math.args[1].args[1].id == "p1"

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -349,7 +349,7 @@ end
     )
 
     test_math = readSBML(
-        joinpath(@__DIR__, "data", "sbml00878.xml"),
+        joinpath(@__DIR__, "data", "00878-sbml-l3v2.xml"),
         doc -> begin
             set_level_and_version(3, 1)(doc)
             convert_promotelocals_expandfuns(doc)


### PR DESCRIPTION
The initial assignment may contain parameters. If these parameters shall be optimised, the `convert_simplify_math` converter must not be used. Instead, the `convert_promote_expand` converter from this PR should be used. I could put it into SBMLtk, but I think it better fits in SBML.jl, cause this is the package that actually does the conversion.