### PR TITLE
clean up the SBML test suite URL machinery

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,10 @@
 name = "SBML"
 uuid = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
 authors = ["Mirek Kratochvil <miroslav.kratochvil@uni.lu>", "LCSB R3 team <lcsb-r3@uni.lu>"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 SBML_jll = "bb12108a-f4ef-5f88-8ef3-0b33ff7017f1"

--- a/src/SBML.jl
+++ b/src/SBML.jl
@@ -9,7 +9,6 @@ using DocStringExtensions
 using IfElse
 using SparseArrays
 using Unitful
-using Downloads
 
 include("types.jl")
 include("structs.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -437,38 +437,16 @@ function Base.show(io::IO, ::MIME"text/plain", m::SBML.Model)
     )
 end
 
-function string_from_url(url; headers = [])
-    io = IOBuffer()
-    Downloads.download(url, io; headers)
-    String(take!(io))
-end
+"""
+$(TYPEDSIGNATURES)
 
-function test_suite_url(case; level = 3, version = 2)
-    case_str = lpad(string(case), 5, '0')
-    "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/release/cases/semantic/$case_str/$case_str-sbml-l$(level)v$(version).xml"
-end
-
-DEFAULT_CONVERT_FUNCTION = doc -> begin
-    set_level_and_version(3, 2)(doc)
-    convert_promotelocals_expandfuns(doc)
-end
-
-function default_convert_function(level, version)
-    doc -> begin
-        set_level_and_version(level, version)(doc)
-        convert_promotelocals_expandfuns(doc)
+Get the URL of a SBML test case file in the `sbmlteam/sbml-test-suite` GitHub
+repository. The URL can be downloaded using `Downloads.download` or any other
+function. Preferably, users should implement a download cache and verify the
+consistency of the downloaded files before using them.
+"""
+test_suite_url(case::Int; ref = "release", level = 3, version = 2) =
+    let
+        case_str = lpad(string(case), 5, '0')
+        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/$ref/cases/semantic/$case_str/$case_str-sbml-l$(level)v$(version).xml"
     end
-end
-
-function readSBMLFromURL(url; conv_f = DEFAULT_CONVERT_FUNCTION)
-    SBML.readSBMLFromString(string_from_url(url), conv_f)
-end
-
-function readSBMLTestCase(
-    case;
-    level = 3,
-    version = 2,
-    conv_f = default_convert_function(level, version),
-)
-    readSBMLFromURL(test_suite_url(case; level, version); conv_f)
-end

--- a/test/downloads.jl
+++ b/test/downloads.jl
@@ -1,5 +1,0 @@
-
-url = "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/release/cases/semantic/00878/00878-sbml-l3v2.xml"
-@test isequal(url, SBML.test_suite_url(878))
-m = SBML.readSBMLTestCase(878)
-m2 = SBML.readSBMLTestCase(878; level = 2, version = 4)

--- a/test/loaddynamicmodels.jl
+++ b/test/loaddynamicmodels.jl
@@ -8,7 +8,7 @@ sbmlfiles = [
     # sbml_test_suite case 00001
     (
         joinpath(@__DIR__, "data", "00001-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00001/00001-sbml-l3v2.xml",
+        SBML.test_suite_url(1, level = 3, version = 2),
         "3e9a8bfe27343459d7a1e462fc3fd4eb2b01dc7b32af1db06a98f366287da01a",
         x -> nothing,
         1,
@@ -18,7 +18,7 @@ sbmlfiles = [
     # case 00001 in older level and version
     (
         joinpath(@__DIR__, "data", "00001-sbml-l2v1.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00001/00001-sbml-l2v1.xml",
+        SBML.test_suite_url(1, level = 2, version = 1),
         "71a145c58b08e475d76bdec644589b2a55b5c5c2fee218274c91677c0f30b508",
         SBML.set_level_and_version(3, 2),
         1,
@@ -28,7 +28,7 @@ sbmlfiles = [
     # case 00057 with localParameters
     (
         joinpath(@__DIR__, "data", "00057-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00057/00057-sbml-l3v2.xml",
+        SBML.test_suite_url(57, level = 3, version = 2),
         "3e84e19cebbb79eea879847f541b1d22db6eb239f1f070ef4609f04c77688659",
         SBML.libsbml_convert("promoteLocalParameters"),
         2,
@@ -41,7 +41,7 @@ sbmlfiles = [
     # case 00025 with functionDefinition
     (
         joinpath(@__DIR__, "data", "00025-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00025/00025-sbml-l3v2.xml",
+        SBML.test_suite_url(25, level = 3, version = 2),
         "d3231ae3858d9e5dca1b106aa7b106a0caee9e6967ef8413de6b9acde9171c3e",
         SBML.libsbml_convert("expandFunctionDefinitions"),
         1,
@@ -51,7 +51,7 @@ sbmlfiles = [
     # case 00036 with initialAssignment
     (
         joinpath(@__DIR__, "data", "00037-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00037/00037-sbml-l3v2.xml",
+        SBML.test_suite_url(37, level = 3, version = 2),
         "074f0caeaf2cdc390967bfdf06d80ccad519c648df7f421dc4e9c69e71551dff",
         SBML.libsbml_convert("expandInitialAssignments"),
         2,

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -29,8 +29,8 @@ sbmlfiles = [
     ),
     # a cool model with `time` from SBML testsuite
     (
-        joinpath(@__DIR__, "data", "sbml00852.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00852/00852-sbml-l3v2.xml",
+        joinpath(@__DIR__, "data", "00852-sbml-l3v2.xml"),
+        SBML.test_suite_url(852, level = 3, version = 2),
         "d013765aa358d265941420c2e3d81fcbc24b0aa4e9f39a8dc8852debd1addb60",
         4,
         3,
@@ -38,8 +38,8 @@ sbmlfiles = [
     ),
     # a cool model with assignmentRule for a compartment
     (
-        joinpath(@__DIR__, "data", "sbml00140.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00140/00140-sbml-l3v2.xml",
+        joinpath(@__DIR__, "data", "00140-sbml-l3v2.xml"),
+        SBML.test_suite_url(140, level = 3, version = 2),
         "43f0151c4f414b610b46bb62033fdcc177f4ac5cc39f3fe8b208e2e335c8d847",
         3,
         1,
@@ -47,8 +47,8 @@ sbmlfiles = [
     ),
     # another model from SBML suite, with initial concentrations
     (
-        joinpath(@__DIR__, "data", "sbml00374.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00374/00374-sbml-l3v2.xml",
+        joinpath(@__DIR__, "data", "00374-sbml-l3v2.xml"),
+        SBML.test_suite_url(374, level = 3, version = 2),
         "424683eea6bbb577aad855d95f2de5183a36e296b06ba18b338572cd7dba6183",
         4,
         2,
@@ -56,8 +56,8 @@ sbmlfiles = [
     ),
     # this contains some special math
     (
-        joinpath(@__DIR__, "data", "sbml01565.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/01565/01565-sbml-l3v1.xml",
+        joinpath(@__DIR__, "data", "01565-sbml-l3v1.xml"),
+        SBML.test_suite_url(1565, level = 3, version = 1),
         "14a80fbce316eea2adb566f67b4668ad151db8954e487309852ece7f730c8c99",
         104,
         52,
@@ -65,8 +65,8 @@ sbmlfiles = [
     ),
     # this contains l3v1-incompatible contents
     (
-        joinpath(@__DIR__, "data", "sbml01289.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/01289/01289-sbml-l3v2.xml",
+        joinpath(@__DIR__, "data", "01289-sbml-l3v2.xml"),
+        SBML.test_suite_url(1289, level = 3, version = 2),
         "35ffa072052970b92fa358ee0f5750394ad74958e889cb85c98ed238642de4d0",
         0,
         0,
@@ -74,8 +74,8 @@ sbmlfiles = [
     ),
     # this contains a relational operator
     (
-        joinpath(@__DIR__, "data", "sbml00191.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00191/00191-sbml-l3v2.xml",
+        joinpath(@__DIR__, "data", "00191-sbml-l3v2.xml"),
+        SBML.test_suite_url(191, level = 3, version = 2),
         "c474e94888767d70f9e9e03b32778f18069641563953de60dabac7daa7f481ce",
         4,
         2,
@@ -84,7 +84,7 @@ sbmlfiles = [
     # expandInitialAssignments converter gives some warning
     (
         joinpath(@__DIR__, "data", "01234-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/52d94baf97a005b6e1fdbdb6116f5c7b4a8a100c/cases/semantic/01234/01234-sbml-l3v2.xml",
+        SBML.test_suite_url(1234, level = 3, version = 2),
         "9610ef29f2d767af627042a15bde505b068ab75bbf00b8983823800ea8ef67c8",
         0,
         0,
@@ -92,7 +92,7 @@ sbmlfiles = [
     ),
     (
         joinpath(@__DIR__, "data", "00489-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00489/00489-sbml-l3v2.xml",
+        SBML.test_suite_url(489, level = 3, version = 2),
         "dab2bce4e5036fa47ad8137055ca5f6dec6dfcb183542ce38573ca2e5a615813",
         3,
         2,
@@ -101,7 +101,7 @@ sbmlfiles = [
     # has listOfEvents
     (
         joinpath(@__DIR__, "data", "00026-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00026/00026-sbml-l3v2.xml",
+        SBML.test_suite_url(26, level = 3, version = 2),
         "991381015d9408164bf00206848ba5796d0c86dc055be91968cd7f0f68daa903",
         2,
         1,
@@ -110,7 +110,7 @@ sbmlfiles = [
     # has all rules types
     (
         joinpath(@__DIR__, "data", "00983-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00983/00983-sbml-l3v2.xml",
+        SBML.test_suite_url(983, level = 3, version = 2),
         "b84e53cc48edd5afc314e17f05c6a30a509aadb9486b3d788c7cf8df82a7527f",
         0,
         0,
@@ -119,7 +119,7 @@ sbmlfiles = [
     # has all kinds of default model units
     (
         joinpath(@__DIR__, "data", "00054-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/semantic/00054/00054-sbml-l3v2.xml",
+        SBML.test_suite_url(54, level = 3, version = 2),
         "987038ec9bb847123c41136928462d7ed05ad697cc414cab09fcce9f5bbc8e73",
         3,
         2,
@@ -128,7 +128,7 @@ sbmlfiles = [
     # has conversionFactor model attribute
     (
         joinpath(@__DIR__, "data", "00975-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/release/cases/semantic/00975/00975-sbml-l3v2.xml",
+        SBML.test_suite_url(975, level = 3, version = 2),
         "e32c12b7bebfa8f146b8860cd8b82d5cad326c96c6a0d8ceb191591ac4e2f5ac",
         2,
         3,
@@ -137,7 +137,7 @@ sbmlfiles = [
     # has the Avogadro "constant"
     (
         joinpath(@__DIR__, "data", "01323-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/release/cases/semantic/01323/01323-sbml-l3v2.xml",
+        SBML.test_suite_url(1323, level = 3, version = 2),
         "9d9121b4f1f38f827a81a884c106c8ade6a8db29e148611c76e515775923a7fc",
         0,
         0,
@@ -146,7 +146,7 @@ sbmlfiles = [
     # contains initialAssignment
     (
         joinpath(@__DIR__, "data", "00878-sbml-l3v2.xml"),
-        "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/release/cases/semantic/00878/00878-sbml-l3v2.xml",
+        SBML.test_suite_url(878, level = 3, version = 2),
         "5f70555d27469a2fdc63dedcd8d02d50b6f4f1c760802cbb5e7bb17363c2e931",
         2,
         1,
@@ -206,12 +206,12 @@ end
     contains_time(x::SBML.MathApply) = any(contains_time.(x.args))
     contains_time(_) = false
 
-    m = readSBML(joinpath(@__DIR__, "data", "sbml00852.xml"))
+    m = readSBML(joinpath(@__DIR__, "data", "00852-sbml-l3v2.xml"))
     @test all(contains_time.(r.kinetic_math for (_, r) in m.reactions))
 end
 
 @testset "Units" begin
-    m = readSBML(joinpath(@__DIR__, "data", "sbml00852.xml"))
+    m = readSBML(joinpath(@__DIR__, "data", "00852-sbml-l3v2.xml"))
     @test SBML.unitful(m.units["volume"]) == 1 * u"L"
     @test SBML.unitful(m.units["time"]) == 1 * u"s"
     @test SBML.unitful(m.units["substance"]) == 1 * u"mol"
@@ -222,7 +222,7 @@ end
 end
 
 @testset "Initial amounts and concentrations" begin
-    m = readSBML(joinpath(@__DIR__, "data", "sbml00852.xml"))
+    m = readSBML(joinpath(@__DIR__, "data", "00852-sbml-l3v2.xml"))
 
     @test all(isnothing(ic) for (k, ic) in SBML.initial_concentrations(m))
     @test length(SBML.initial_amounts(m)) == 4
@@ -232,7 +232,7 @@ end
         0.001,
     )
 
-    m = readSBML(joinpath(@__DIR__, "data", "sbml00374.xml"))
+    m = readSBML(joinpath(@__DIR__, "data", "00374-sbml-l3v2.xml"))
 
     @test all(isnothing(ic) for (k, ic) in SBML.initial_amounts(m))
     @test length(SBML.initial_concentrations(m)) == 4
@@ -248,7 +248,7 @@ end
     @test m.initial_assignments ==
           Dict("S1" => SBML.MathApply("*", [SBML.MathVal{Int32}(2), SBML.MathIdent("p1")]))
 
-    m = readSBML(joinpath(@__DIR__, "data", "sbml01289.xml"))
+    m = readSBML(joinpath(@__DIR__, "data", "01289-sbml-l3v2.xml"))
     @test m.initial_assignments == Dict(
         "p2" => SBML.MathApply("gt5", [SBML.MathVal{Int32}(8)]),
         "p1" => SBML.MathApply("gt5", [SBML.MathVal{Int32}(3)]),
@@ -307,7 +307,7 @@ end
 end
 
 @testset "Extensive kinetic math" begin
-    m = readSBML(joinpath(@__DIR__, "data", "sbml00852.xml"))
+    m = readSBML(joinpath(@__DIR__, "data", "00852-sbml-l3v2.xml"))
 
     subterm =
         SBML.extensive_kinetic_math(m, m.reactions["reaction1"].kinetic_math).args[1].args[2]
@@ -315,7 +315,7 @@ end
     @test subterm.args[1] == SBML.MathIdent("S1")
     @test subterm.args[2] == SBML.MathIdent("C")
 
-    m = readSBML(joinpath(@__DIR__, "data", "sbml00140.xml"))
+    m = readSBML(joinpath(@__DIR__, "data", "00140-sbml-l3v2.xml"))
 
     subterm = SBML.extensive_kinetic_math(m, m.reactions["reaction1"].kinetic_math).args[2]
     @test subterm.fn == "/"
@@ -324,7 +324,7 @@ end
 end
 
 @testset "logBase and root math functions" begin
-    m = readSBML(joinpath(@__DIR__, "data", "sbml01565.xml"))
+    m = readSBML(joinpath(@__DIR__, "data", "01565-sbml-l3v1.xml"))
 
     if TEST_SYMBOLICS
         @test interpret_as_num(m.reactions["J23"].kinetic_math) == 0.0
@@ -341,7 +341,7 @@ end
 
 @testset "converters work and fail gracefully" begin
     @test_logs (:error, r"^SBML reported error:") (:error, r"^SBML reported error:") @test_throws ErrorException readSBML(
-        joinpath(@__DIR__, "data", "sbml01289.xml"),
+        joinpath(@__DIR__, "data", "01289-sbml-l3v2.xml"),
         doc -> begin
             set_level_and_version(3, 1)(doc)
             convert_simplify_math(doc)
@@ -364,7 +364,7 @@ end
 
     test_math =
         readSBML(
-            joinpath(@__DIR__, "data", "sbml01565.xml"),
+            joinpath(@__DIR__, "data", "01565-sbml-l3v1.xml"),
             libsbml_convert("expandInitialAssignments"),
         ).reactions["J31"].kinetic_math
 
@@ -380,7 +380,7 @@ end
 
 @testset "relational operators are decoded correctly" begin
     test_math =
-        readSBML(joinpath(@__DIR__, "data", "sbml00191.xml")).reactions["reaction2"].kinetic_math
+        readSBML(joinpath(@__DIR__, "data", "00191-sbml-l3v2.xml")).reactions["reaction2"].kinetic_math
 
     @test test_math.args[2].fn == "geq"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,5 +31,4 @@ include("common.jl")
     include("writemodels.jl") # depends on `sbmlfiles` from loadmodels.jl
     include("loaddynamicmodels.jl")
     include("interpret.jl")
-    include("downloads.jl")
 end


### PR DESCRIPTION
- remove undocumented functions (This unfortunately comprises most of #241 - I can't support/release these without proper docs, and the "direct" use of `Downloads` should be discouraged at all cost. I think we could release the loader functions but they must not be called "default", because they are totallu nondefault in most contexts I've seen.)
- test the URL-generating function
- clean up urlblobs and file naming in tests

Also this bumps up the version, let's release. :]