### PR TITLE
add sbmlPower dispatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBML"
 uuid = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
 authors = ["Mirek Kratochvil <miroslav.kratochvil@uni.lu>", "LCSB R3 team <lcsb-r3@uni.lu>"]
-version = "1.4.3"
+version = "1.4.4"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -21,7 +21,8 @@ end
 sbmlLog(x) = sbmlLog(10, x)
 sbmlLog(base, x) = log(base, x)
 
-sbmlPower(x, y) = x^float(y)
+sbmlPower(x, y::Int) = x^float(y)
+sbmlPower(x, y) = x^y
 sbmlRoot(x) = sqrt(x)
 sbmlRoot(power, x) = x^(1 / power)
 

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -21,7 +21,7 @@ end
 sbmlLog(x) = sbmlLog(10, x)
 sbmlLog(base, x) = log(base, x)
 
-sbmlPower(x, y::Int) = x^float(y)
+sbmlPower(x::Int, y::Int) = x^float(y)
 sbmlPower(x, y) = x^y
 sbmlRoot(x) = sqrt(x)
 sbmlRoot(power, x) = x^(1 / power)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -21,7 +21,7 @@ end
 sbmlLog(x) = sbmlLog(10, x)
 sbmlLog(base, x) = log(base, x)
 
-sbmlPower(x::Int, y::Int) = x^float(y)
+sbmlPower(x::Integer, y::Integer) = x^float(y)
 sbmlPower(x, y) = x^y
 sbmlRoot(x) = sqrt(x)
 sbmlRoot(power, x) = x^(1 / power)


### PR DESCRIPTION
This fixes the following bug I saw:
```
ERROR: ArgumentError: Cannot convert Sym to AbstractFloat since Sym is symbolic and AbstractFloat is concrete. Use `substitute` to replace the symbolic unwraps.
Stacktrace:
  [1] AbstractFloat(x::SymbolicUtils.BasicSymbolic{Real})
    @ Symbolics ~/.julia/packages/Symbolics/k84uz/src/Symbolics.jl:146
  [2] float(x::SymbolicUtils.BasicSymbolic{Real})
    @ Base ./float.jl:294
  [3] sbmlPower(x::SymbolicUtils.BasicSymbolic{Real}, y::SymbolicUtils.BasicSymbolic{Real})
    @ SBML ~/.julia/packages/SBML/GYWJL/src/interpret.jl:24
```