### PR TITLE
use IfElse.jl for Julia 1.6"

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -7,7 +7,7 @@ function sbmlPiecewise(args...)
     elseif length(args) >= 3
         IfElse.ifelse(args[2], args[1], sbmlPiecewise(args[3:end]...))
     else
-        throw(DomainError(args, "malformed piecewise SBML function"))
+        IfElse.ifelse(args[2], args[1], NaN)
     end
 end
 


### PR DESCRIPTION
I could imagine that  #251 fails on Julia 1.6, because it requires IfElse.jl. Let's see if CI passes for this.