### PR TITLE
Add support for specie conversionFactor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBML"
 uuid = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
 authors = ["Mirek Kratochvil <miroslav.kratochvil@uni.lu>", "LCSB R3 team <lcsb-r3@uni.lu>"]
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -412,9 +412,9 @@ function get_model(mdl::VPtr)::SBML.Model
                 ccall(sbml(:Species_getInitialConcentration), Cdouble, (VPtr,), sp)
             end,
             substance_units = get_optional_string(sp, :Species_getSubstanceUnits),
-	    conversion_factor = if (
+            conversion_factor = if (
                 ccall(sbml(:Species_getConversionFactor), Cstring, (VPtr,), sp) != C_NULL
-            )   
+            )
                 get_string(sp, :Species_getConversionFactor)
             end,
             only_substance_units = get_optional_bool(

--- a/src/readsbml.jl
+++ b/src/readsbml.jl
@@ -412,6 +412,11 @@ function get_model(mdl::VPtr)::SBML.Model
                 ccall(sbml(:Species_getInitialConcentration), Cdouble, (VPtr,), sp)
             end,
             substance_units = get_optional_string(sp, :Species_getSubstanceUnits),
+	    conversion_factor = if (
+                ccall(sbml(:Species_getConversionFactor), Cstring, (VPtr,), sp) != C_NULL
+            )   
+                get_string(sp, :Species_getConversionFactor)
+            end,
             only_substance_units = get_optional_bool(
                 sp,
                 :Species_isSetHasOnlySubstanceUnits,

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -354,6 +354,7 @@ Base.@kwdef struct Species
     initial_amount::Maybe{Float64} = nothing
     initial_concentration::Maybe{Float64} = nothing
     substance_units::Maybe{String} = nothing
+    conversion_factor::Maybe{String} = nothing
     only_substance_units::Maybe{Bool} = nothing
     constant::Maybe{Bool} = nothing
     metaid::Maybe{String} = nothing

--- a/src/writesbml.jl
+++ b/src/writesbml.jl
@@ -415,6 +415,7 @@ function model_to_sbml!(doc::VPtr, mdl::Model)::VPtr
             species.initial_concentration,
         )
         set_string!(species_ptr, :Species_setSubstanceUnits, species.substance_units)
+        set_string!(species_ptr, :Species_setConversionFactor, species.conversion_factor)
         set_bool!(
             species_ptr,
             :Species_setHasOnlySubstanceUnits,

--- a/test/loadmodels.jl
+++ b/test/loadmodels.jl
@@ -134,6 +134,15 @@ sbmlfiles = [
         3,
         fill(Inf, 3),
     ),
+    # has conversionFactor species attribute
+    (
+        joinpath(@__DIR__, "data", "00976-sbml-l3v2.xml"),
+        SBML.test_suite_url(976, level = 3, version = 2),
+        "6cec83157cd81a585597c02f225e814a9ce2a1c9255a039b3083c97cfe02dd00",
+        2,
+        3,
+        fill(Inf, 3),
+    ),
     # has the Avogadro "constant"
     (
         joinpath(@__DIR__, "data", "01323-sbml-l3v2.xml"),
@@ -426,6 +435,9 @@ end
     @test isnothing(m.time_units)
     @test isnothing(m.volume_units)
     @test isnothing(m.active_objective)
+
+    m = readSBML(joinpath(@__DIR__, "data", "00976-sbml-l3v2.xml"))
+    @test m.species["S1"].conversion_factor == "S1conv"
 end
 
 @testset "names and identifiers of objects" begin


### PR DESCRIPTION
Closes #257 

With this implementation the PEtab.jl SBML importer passes the SBML tests with specie conversion factor. Also, I do not encounter any problem on the other test cases.