### PR TITLE
Add SBMLImporter to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ You might like to try the packages that use SBML.jl; these now include:
   constraint-based analysis and reconstruction toolkit for finding and modeling
   steady metabolic fluxes with the models
 - [SBMLToolkit.jl](https://github.com/SciML/SBMLToolkit.jl), for working with
-  the reaction dynamics of the models as ODE systems, well connected to the
+  the reaction dynamics of the models as ODE systems, well-connected to the
+  [SciML](https://github.com/SciML)
+  [ModelingToolkit](https://github.com/SciML/ModelingToolkit.jl) ecosystem.
+- [SBMLImporter.jl](https://github.com/sebapersson/SBMLImporter.jl) for working 
+  with dynamic models, similar to SBMLToolkit. It supports importing models as 
+  Jump problems, SDE systems, and ODE systems. Well-connected to the
   [SciML](https://github.com/SciML)
   [ModelingToolkit](https://github.com/SciML/ModelingToolkit.jl) ecosystem.
 


### PR DESCRIPTION
As SBMLImporter heavily relies on SBML.jl for importing SBML models, I think it would be nice to include it in the README along the packages that use SBML.jl.